### PR TITLE
Parse ISO datetime objects

### DIFF
--- a/fintoc/mixins/resource_mixin.py
+++ b/fintoc/mixins/resource_mixin.py
@@ -30,7 +30,8 @@ class ResourceMixin(metaclass=ABCMeta):
                 klass = get_resource_class(resource, value=value)
                 setattr(self, key, objetize(klass, client, value))
             else:
-                setattr(self, key, value)
+                klass = get_resource_class(resource, value=value)
+                setattr(self, key, objetize(klass, client, value))
 
     def __getattr__(self, attr):
         if attr not in self._methods:

--- a/fintoc/mixins/resource_mixin.py
+++ b/fintoc/mixins/resource_mixin.py
@@ -26,9 +26,6 @@ class ResourceMixin(metaclass=ABCMeta):
                 element = {} if not value else value[0]
                 klass = get_resource_class(resource, value=element)
                 setattr(self, key, [objetize(klass, client, x) for x in value])
-            elif isinstance(value, dict):
-                klass = get_resource_class(resource, value=value)
-                setattr(self, key, objetize(klass, client, value))
             else:
                 klass = get_resource_class(resource, value=value)
                 setattr(self, key, objetize(klass, client, value))

--- a/fintoc/utils.py
+++ b/fintoc/utils.py
@@ -2,8 +2,8 @@
 
 from importlib import import_module
 
-from dateutil import parser
 import httpx
+from dateutil import parser
 
 from fintoc.errors import FintocError
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -387,6 +387,17 @@ toml = "*"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "regex"
 version = "2021.8.3"
 description = "Alternative regular expression module, to replace re."
@@ -407,6 +418,14 @@ idna = {version = "*", optional = true, markers = "extra == \"idna2008\""}
 
 [package.extras]
 idna2008 = ["idna"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "sniffio"
@@ -466,7 +485,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "36342eb6dab47343d0339b7a3c4c08d8791860149e3181010443c8288fee292e"
+content-hash = "b9ffc636c7d1190f961df9bd23472bfc47b48931309127634072e7f87bf789bb"
 
 [metadata.files]
 appdirs = [
@@ -686,6 +705,10 @@ pytest-cov = [
     {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
     {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
 ]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
 regex = [
     {file = "regex-2021.8.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8764a78c5464ac6bde91a8c87dd718c27c1cabb7ed2b4beaf36d3e8e390567f9"},
     {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4551728b767f35f86b8e5ec19a363df87450c7376d7419c3cac5b9ceb4bce576"},
@@ -724,6 +747,10 @@ regex = [
 rfc3986 = [
     {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
     {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 sniffio = [
     {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ exclude = [
 [tool.poetry.dependencies]
 python = "^3.6"
 httpx = ">=0.16, < 1.0"
+python-dateutil = ">=2.8, < 3.0"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 from types import GeneratorType
 
+from dateutil import parser
 import httpx
 import pytest
 
@@ -9,6 +10,7 @@ from fintoc.utils import (
     can_raise_http_error,
     get_error_class,
     get_resource_class,
+    is_iso_datetime,
     objetize,
     objetize_generator,
     singularize,
@@ -50,6 +52,16 @@ class TestSingularize:
         assert singular != "formula"
 
 
+class TestIsISODateTime:
+    def test_valid_iso_format(self):
+        valid_iso_datetime_string = "2021-08-13T13:40:40.811Z"
+        assert is_iso_datetime(valid_iso_datetime_string)
+
+    def test_invalid_iso_format(self):
+        invalid_iso_datetime_string = "This is not a date"
+        assert not is_iso_datetime(invalid_iso_datetime_string)
+
+
 class TestGetResourceClass:
     def test_default_valid_resource(self):
         resource = "link"
@@ -61,10 +73,25 @@ class TestGetResourceClass:
         klass = get_resource_class(resource)
         assert klass is GenericFintocResource
 
+    def test_iso_datetime_resource(self):
+        resource = "any_resource"
+        klass = get_resource_class(resource, value="2021-08-13T13:40:40.811Z")
+        assert klass is parser.isoparse
+
     def test_string_resource(self):
         resource = "any_resource"
         klass = get_resource_class(resource, value="test-value")
         assert klass is str
+
+    def test_int_resource(self):
+        resource = "any_resource"
+        klass = get_resource_class(resource, value=15)
+        assert klass is int
+
+    def test_bool_resource(self):
+        resource = "any_resource"
+        klass = get_resource_class(resource, value=True)
+        assert klass is bool
 
     def test_integer_resource(self):
         resource = "any_resource"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
 from types import GeneratorType
 
-from dateutil import parser
 import httpx
 import pytest
+from dateutil import parser
 
 from fintoc.errors import ApiError, FintocError
 from fintoc.resources import GenericFintocResource, Link


### PR DESCRIPTION
## Description

This Pull Request makes it so that the SDK parses dates on objects instead of leaving them as simple strings.

Closes #11

## Requirements

None.

## Additional changes

One dependency was added, the `python-dateutil` library. This was necessary for the "_loose_" ISO datetime parsing.