### PR TITLE
Add serialization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,18 @@ for movement in account.movements.all():
     print(movement.id)
 ```
 
+### Serialization
+
+Any resource of the SDK can be serialized! To get the serialized resource, just call the `serialize` method!
+
+```python
+account = link.accounts.all(lazy=False)[0]
+
+serialization = account.serialize()
+```
+
+The serialization corresponds to a dictionary with only simple types, that can be JSON-serialized.
+
 ## Acknowledgements
 
 The first version of this SDK was originally designed and handcrafted by [**@nebil**](https://github.com/nebil),

--- a/fintoc/mixins/resource_mixin.py
+++ b/fintoc/mixins/resource_mixin.py
@@ -18,17 +18,21 @@ class ResourceMixin(metaclass=ABCMeta):
         self._handlers = handlers
         self._methods = methods
         self._path = path
+        self._attributes = []
 
         for key, value in kwargs.items():
-            resource = self.__class__.mappings.get(key, key)
-            if isinstance(value, list):
-                resource = singularize(resource)
-                element = {} if not value else value[0]
-                klass = get_resource_class(resource, value=element)
-                setattr(self, key, [objetize(klass, client, x) for x in value])
-            else:
-                klass = get_resource_class(resource, value=value)
-                setattr(self, key, objetize(klass, client, value))
+            try:
+                resource = self.__class__.mappings.get(key, key)
+                if isinstance(value, list):
+                    resource = singularize(resource)
+                    element = {} if not value else value[0]
+                    klass = get_resource_class(resource, value=element)
+                    setattr(self, key, [objetize(klass, client, x) for x in value])
+                else:
+                    klass = get_resource_class(resource, value=value)
+                    setattr(self, key, objetize(klass, client, value))
+            except NameError:
+                pass
 
     def __getattr__(self, attr):
         if attr not in self._methods:

--- a/fintoc/mixins/resource_mixin.py
+++ b/fintoc/mixins/resource_mixin.py
@@ -37,7 +37,7 @@ class ResourceMixin(metaclass=ABCMeta):
                 else:
                     klass = get_resource_class(resource, value=value)
                     setattr(self, key, objetize(klass, client, value))
-            except NameError:
+            except NameError:  # pragma: no cover
                 pass
 
     def __getattr__(self, attr):
@@ -49,7 +49,15 @@ class ResourceMixin(metaclass=ABCMeta):
 
     def serialize(self):
         """Serialize the resource."""
-        return {key: serialize(self.__dict__[key]) for key in self._attributes}
+        serialized = {}
+        for key in self._attributes:
+            element = (
+                [serialize(x) for x in self.__dict__[key]]
+                if isinstance(self.__dict__[key], list)
+                else serialize(self.__dict__[key])
+            )
+            serialized = {**serialized, key: element}
+        return serialized
 
     @can_raise_http_error
     def _update(self, **kwargs):

--- a/fintoc/mixins/resource_mixin.py
+++ b/fintoc/mixins/resource_mixin.py
@@ -37,6 +37,7 @@ class ResourceMixin(metaclass=ABCMeta):
                 else:
                     klass = get_resource_class(resource, value=value)
                     setattr(self, key, objetize(klass, client, value))
+                self._attributes.append(key)
             except NameError:  # pragma: no cover
                 pass
 

--- a/fintoc/mixins/resource_mixin.py
+++ b/fintoc/mixins/resource_mixin.py
@@ -3,7 +3,13 @@
 from abc import ABCMeta
 
 from fintoc.resource_handlers import resource_delete, resource_update
-from fintoc.utils import can_raise_http_error, get_resource_class, objetize, singularize
+from fintoc.utils import (
+    can_raise_http_error,
+    get_resource_class,
+    objetize,
+    serialize,
+    singularize,
+)
 
 
 class ResourceMixin(metaclass=ABCMeta):
@@ -40,6 +46,10 @@ class ResourceMixin(metaclass=ABCMeta):
                 f"{self.__class__.__name__} has no attribute '{attr.lstrip('_')}'"
             )
         return getattr(self, f"_{attr}")
+
+    def serialize(self):
+        """Serialize the resource."""
+        return {key: serialize(self.__dict__[key]) for key in self._attributes}
 
     @can_raise_http_error
     def _update(self, **kwargs):

--- a/fintoc/resources/account.py
+++ b/fintoc/resources/account.py
@@ -23,4 +23,4 @@ class Account(ResourceMixin):
 
     @movements.setter
     def movements(self, new_value):  # pylint: disable=no-self-use
-        return
+        raise NameError("Attribute name corresponds to a manager")

--- a/fintoc/resources/link.py
+++ b/fintoc/resources/link.py
@@ -26,7 +26,7 @@ class Link(ResourceMixin):
 
     @accounts.setter
     def accounts(self, new_value):  # pylint: disable=no-self-use
-        return
+        raise NameError("Attribute name corresponds to a manager")
 
     @property
     def subscriptions(self):
@@ -39,7 +39,7 @@ class Link(ResourceMixin):
 
     @subscriptions.setter
     def subscriptions(self, new_value):  # pylint: disable=no-self-use
-        return
+        raise NameError("Attribute name corresponds to a manager")
 
     @property
     def tax_returns(self):
@@ -50,7 +50,7 @@ class Link(ResourceMixin):
 
     @tax_returns.setter
     def tax_returns(self, new_value):  # pylint: disable=no-self-use
-        return
+        raise NameError("Attribute name corresponds to a manager")
 
     @property
     def invoices(self):
@@ -61,4 +61,4 @@ class Link(ResourceMixin):
 
     @invoices.setter
     def invoices(self, new_value):  # pylint: disable=no-self-use
-        return
+        raise NameError("Attribute name corresponds to a manager")

--- a/fintoc/utils.py
+++ b/fintoc/utils.py
@@ -1,5 +1,6 @@
 """Module to hold every generalized utility on the SDK."""
 
+import datetime
 from importlib import import_module
 
 import httpx
@@ -70,6 +71,15 @@ def can_raise_http_error(function):
             raise error(error_data["error"]) from None
 
     return wrapper
+
+
+def serialize(object_):
+    """Serializes an object."""
+    if callable(getattr(object_, "serialize", None)):
+        return object_.serialize()
+    if isinstance(object_, datetime.datetime):
+        return object_.isoformat()
+    return object_
 
 
 def objetize(klass, client, data, handlers={}, methods=[], path=None):

--- a/tests/mixins/test_resource_mixin.py
+++ b/tests/mixins/test_resource_mixin.py
@@ -100,6 +100,57 @@ class TestResourceMixinCreation:
         resource.delete()
 
 
+class TestMixinSerializeMethod:
+    @pytest.fixture(autouse=True)
+    def patch_http_client(self, patch_http_client):
+        pass
+
+    def setup_method(self):
+        self.base_url = "https://test.com"
+        self.api_key = "super_secret_api_key"
+        self.user_agent = "fintoc-python/test"
+        self.params = {"first_param": "first_value", "second_param": "second_value"}
+        self.client = Client(
+            self.base_url,
+            self.api_key,
+            self.user_agent,
+            params=self.params,
+        )
+        self.path = "/resources"
+        self.handlers = {
+            "update": lambda object_, identifier: print("Calling update...") or object_,
+            "delete": lambda identifier: print("Calling delete...") or identifier,
+        }
+
+    def test_serialization_method(self):
+        methods = ["delete"]
+        data = {
+            "id": "id0",
+            "identifier": "identifier0",
+            "resource": {"id": "id3", "identifier": "identifier3"},
+        }
+        resource = EmptyMockResource(
+            self.client, self.handlers, methods, self.path, **data
+        )
+        assert resource.serialize() == data
+
+    def test_array_serialization_method(self):
+        methods = ["delete"]
+        data = {
+            "id": "id0",
+            "identifier": "identifier0",
+            "resources": [
+                {"id": "id1", "identifier": "identifier1"},
+                {"id": "id2", "identifier": "identifier2"},
+            ],
+            "resource": {"id": "id3", "identifier": "identifier3"},
+        }
+        resource = EmptyMockResource(
+            self.client, self.handlers, methods, self.path, **data
+        )
+        assert resource.serialize() == data
+
+
 class TestMixinUpdateAndDeleteMethods:
     @pytest.fixture(autouse=True)
     def patch_http_client(self, patch_http_client):

--- a/tests/resources/test_account.py
+++ b/tests/resources/test_account.py
@@ -1,3 +1,5 @@
+import pytest
+
 from fintoc.client import Client
 from fintoc.mixins import ManagerMixin
 from fintoc.resources import Account
@@ -30,7 +32,9 @@ class TestAccountResource:
         assert account._Account__movements_manager is not None
         assert isinstance(account._Account__movements_manager, ManagerMixin)
 
-        account.movements = None
+        with pytest.raises(NameError):
+            account.movements = None
+
         assert account.movements is not None
         assert isinstance(account.movements, ManagerMixin)
         assert isinstance(account._Account__movements_manager, ManagerMixin)

--- a/tests/resources/test_link.py
+++ b/tests/resources/test_link.py
@@ -1,3 +1,5 @@
+import pytest
+
 from fintoc.client import Client
 from fintoc.mixins import ManagerMixin
 from fintoc.resources import Link
@@ -30,7 +32,9 @@ class TestLinkResource:
         assert link._Link__accounts_manager is not None
         assert isinstance(link._Link__accounts_manager, ManagerMixin)
 
-        link.accounts = None
+        with pytest.raises(NameError):
+            link.accounts = None
+
         assert link.accounts is not None
         assert isinstance(link.accounts, ManagerMixin)
         assert isinstance(link._Link__accounts_manager, ManagerMixin)
@@ -44,7 +48,9 @@ class TestLinkResource:
         assert link._Link__subscriptions_manager is not None
         assert isinstance(link._Link__subscriptions_manager, ManagerMixin)
 
-        link.subscriptions = None
+        with pytest.raises(NameError):
+            link.subscriptions = None
+
         assert link.subscriptions is not None
         assert isinstance(link.subscriptions, ManagerMixin)
         assert isinstance(link._Link__subscriptions_manager, ManagerMixin)
@@ -58,7 +64,9 @@ class TestLinkResource:
         assert link._Link__tax_returns_manager is not None
         assert isinstance(link._Link__tax_returns_manager, ManagerMixin)
 
-        link.tax_returns = None
+        with pytest.raises(NameError):
+            link.tax_returns = None
+
         assert link.tax_returns is not None
         assert isinstance(link.tax_returns, ManagerMixin)
         assert isinstance(link._Link__tax_returns_manager, ManagerMixin)
@@ -72,7 +80,9 @@ class TestLinkResource:
         assert link._Link__invoices_manager is not None
         assert isinstance(link._Link__invoices_manager, ManagerMixin)
 
-        link.invoices = None
+        with pytest.raises(NameError):
+            link.invoices = None
+
         assert link.invoices is not None
         assert isinstance(link.invoices, ManagerMixin)
         assert isinstance(link._Link__invoices_manager, ManagerMixin)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import datetime
 from types import GeneratorType
 
 import httpx
@@ -13,6 +14,7 @@ from fintoc.utils import (
     is_iso_datetime,
     objetize,
     objetize_generator,
+    serialize,
     singularize,
     snake_to_pascal,
 )
@@ -155,6 +157,38 @@ class ExampleClass:
         self.methods = methods
         self.path = path
         self.data = kwargs
+
+    def serialize(self):
+        return self.data
+
+
+class TestSerialize:
+    def test_string_serialization(self):
+        string = "This is a string"
+        assert serialize(string) == string
+
+    def test_boolean_serialization(self):
+        boolean = True
+        assert serialize(boolean) == boolean
+
+    def test_int_serialization(self):
+        integer = 3
+        assert serialize(integer) == integer
+
+    def test_none_serialization(self):
+        none = None
+        assert serialize(none) == none
+
+    def test_datetime_serialization(self):
+        now = datetime.datetime.now()
+        assert isinstance(now, datetime.datetime)
+        assert isinstance(serialize(now), str)
+        assert serialize(now) == now.isoformat()
+
+    def test_object_with_serialize_method_serialization(self):
+        data = {"a": "b", "c": "d"}
+        object_ = ExampleClass("client", ["handler"], ["method"], "path", **data)
+        assert serialize(object_) == object_.serialize()
 
 
 class TestObjetize:


### PR DESCRIPTION
## Description

This Pull Request adds a `serialize` method to every resource, so that they can be serialized o a dictionary with only simple, JSON-serializable types.

Closes #12

## Requirements

None.

## Additional changes

None.
