### PR TITLE
Hide link token

### DIFF
--- a/fintoc/managers/links_manager.py
+++ b/fintoc/managers/links_manager.py
@@ -13,11 +13,11 @@ class LinksManager(ManagerMixin):
     def post_get_handler(self, object_, identifier, **kwargs):
         # pylint: disable=protected-access
         object_._client = self._client.extend(params={"link_token": identifier})
-        object_.link_token = identifier
+        object_._link_token = identifier
         return object_
 
     def post_update_handler(self, object_, identifier, **kwargs):
         # pylint: disable=protected-access
         object_._client = self._client.extend(params={"link_token": identifier})
-        object_.link_token = identifier
+        object_._link_token = identifier
         return object_

--- a/fintoc/resources/link.py
+++ b/fintoc/resources/link.py
@@ -8,7 +8,7 @@ class Link(ResourceMixin):
 
     """Represents a Fintoc Link."""
 
-    resource_identifier = "link_token"
+    resource_identifier = "_link_token"
 
     def __init__(self, client, handlers, methods, path, **kwargs):
         super().__init__(client, handlers, methods, path, **kwargs)

--- a/tests/managers/test_links_manager.py
+++ b/tests/managers/test_links_manager.py
@@ -27,7 +27,6 @@ class TestLinksManagerHandlers:
         # pylint: disable=protected-access
         id_ = "idx"
         object_ = self.manager.get(id_)
-        assert object_.link_token == id_
         assert object_._client is not self.manager._client
         assert "link_token" not in self.manager._client.params
         assert "link_token" in object_._client.params
@@ -36,7 +35,6 @@ class TestLinksManagerHandlers:
         # pylint: disable=protected-access
         id_ = "idx"
         object_ = self.manager.update(id_)
-        assert object_.link_token == id_
         assert object_._client is not self.manager._client
         assert "link_token" not in self.manager._client.params
         assert "link_token" in object_._client.params


### PR DESCRIPTION
## Description

@nateare made me see that we probably shouldn't expose the `link_token` directly on the `Link` object (both because the API doesn't do it and because it may lead to the user accidentally sending sensible data to the frontend), so this Pull Request "_privatizes_" the attribute.

## Requirements

None.

## Additional changes

None.
