### PR TITLE
Refresh Intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ from fintoc import Fintoc
 fintoc_client = Fintoc("your_api_key")
 ```
 
-This gives us access to a bunch of operations already. The object created using this _snippet_ contains two [managers](#managers): `links` and `webhook_endpoints`.
+This gives us access to a bunch of operations already. The object created using this _snippet_ contains three [managers](#managers): `links`, `webhook_endpoints` and `refresh_intents`.
 
 #### The `webhook_endpoints` manager
 
@@ -230,6 +230,33 @@ If you see a webhook endpoint you want to use, just use the `get` method!
 webhook_endpoint = fintoc_client.webhook_endpoints.get("we_8anqVLlBC8ROodem")
 
 print(webhook_endpoint.id)  # we_8anqVLlBC8ROodem
+```
+
+#### The `refresh_intents` manager
+
+Available methods: `all`, `get`, `create`.
+
+Refresh intents allow you to control how an account gets refreshed on Fintoc! Start by creating a new Refresh Intent:
+
+```python
+refresh_intent = fintoc_client.refresh_intents.create()
+
+print(refresh_intent.id)  # ari_5A94DVCJ7xNM3MEo
+```
+
+Notice that the success of this Refresh Intent will be notified through a Webhook. Now, let's list every Refresh Intent we have:
+
+```python
+for refresh_intent in fintoc_client.refresh_intents.all():
+    print(refresh_intent.id)
+```
+
+If you see a Refresh Intent you want to use, just use the `get` method!
+
+```python
+refresh_intent = fintoc_client.refresh_intents.get("ari_5A94DVCJ7xNM3MEo")
+
+print(refresh_intent.id)  # ari_5A94DVCJ7xNM3MEo
 ```
 
 #### The `links` manager

--- a/fintoc/core.py
+++ b/fintoc/core.py
@@ -4,7 +4,7 @@ Core module to house the Fintoc object of the Fintoc Python SDK.
 
 from fintoc.client import Client
 from fintoc.constants import API_BASE_URL, API_VERSION
-from fintoc.managers import LinksManager, WebhookEndpointsManager
+from fintoc.managers import LinksManager, RefreshIntentsManager, WebhookEndpointsManager
 from fintoc.version import __version__
 
 
@@ -22,3 +22,4 @@ class Fintoc:
         self.webhook_endpoints = WebhookEndpointsManager(
             "/webhook_endpoints", self._client
         )
+        self.refresh_intents = RefreshIntentsManager("/refresh_intents", self._client)

--- a/fintoc/managers/__init__.py
+++ b/fintoc/managers/__init__.py
@@ -4,6 +4,7 @@ from .accounts_manager import AccountsManager
 from .invoices_manager import InvoicesManager
 from .links_manager import LinksManager
 from .movements_manager import MovementsManager
+from .refresh_intents_manager import RefreshIntentsManager
 from .subscriptions_manager import SubscriptionsManager
 from .tax_returns_manager import TaxRetunsManager
 from .webhook_endpoints_manager import WebhookEndpointsManager

--- a/fintoc/managers/refresh_intents_manager.py
+++ b/fintoc/managers/refresh_intents_manager.py
@@ -1,0 +1,11 @@
+"""Module to hold the refresh_intents manager."""
+
+from fintoc.mixins import ManagerMixin
+
+
+class RefreshIntentsManager(ManagerMixin):
+
+    """Represents a refresh_intents manager."""
+
+    resource = "refresh_intent"
+    methods = ["all", "get", "create"]

--- a/fintoc/resources/__init__.py
+++ b/fintoc/resources/__init__.py
@@ -11,6 +11,7 @@ from .invoice import Invoice
 from .link import Link
 from .movement import Movement
 from .other_taxes import OtherTaxes
+from .refresh_intent import RefreshIntent
 from .services_invoice import ServicesInvoice
 from .subscription import Subscription
 from .tax_return import TaxReturn

--- a/fintoc/resources/refresh_intent.py
+++ b/fintoc/resources/refresh_intent.py
@@ -1,0 +1,7 @@
+"""Module to hold the RefreshIntent resource."""
+
+from fintoc.mixins import ResourceMixin
+
+
+class RefreshIntent(ResourceMixin):
+    """Represents a Fintoc Refresh Intent."""


### PR DESCRIPTION
## Description

This Pull Request adds support for refresh intents. Note that the `result_status` query param of the `POST` action of the refresh intents isn't supported. I'm waiting on what to do with this parameter, but I think that every parameter should go through the request body on a `POST` request (every other `POST` request has no query params and receives everything through the request body)

## Requirements

None.

## Additional changes

None.
