### PR TITLE
Fix the datetime parser

### DIFF
--- a/fintoc/constants.py
+++ b/fintoc/constants.py
@@ -4,3 +4,4 @@ API_BASE_URL = "https://api.fintoc.com"
 API_VERSION = "v1"
 
 LINK_HEADER_PATTERN = r'<(?P<url>.*)>;\s*rel="(?P<rel>.*)"'
+DATE_TIME_PATTERN = "%Y-%m-%dT%H:%M:%S.%fZ"

--- a/fintoc/utils.py
+++ b/fintoc/utils.py
@@ -4,7 +4,6 @@ import datetime
 from importlib import import_module
 
 import httpx
-from dateutil import parser
 
 from fintoc.constants import DATE_TIME_PATTERN
 from fintoc.errors import FintocError

--- a/fintoc/utils.py
+++ b/fintoc/utils.py
@@ -6,6 +6,7 @@ from importlib import import_module
 import httpx
 from dateutil import parser
 
+from fintoc.constants import DATE_TIME_PATTERN
 from fintoc.errors import FintocError
 
 
@@ -25,7 +26,7 @@ def is_iso_datetime(string):
     Otherwise, return False.
     """
     try:
-        parser.isoparse(string)
+        datetime.datetime.strptime(string, DATE_TIME_PATTERN)
         return True
     except ValueError:
         return False
@@ -43,7 +44,7 @@ def get_resource_class(snake_resource_name, value={}):
         except AttributeError:
             return getattr(module, "GenericFintocResource")
     if isinstance(value, str) and is_iso_datetime(value):
-        return parser.isoparse
+        return objetize_datetime
     return type(value)
 
 
@@ -82,11 +83,16 @@ def serialize(object_):
     return object_
 
 
+def objetize_datetime(string):
+    """Objetizes a datetime string without checking for correctness."""
+    return datetime.datetime.strptime(string, DATE_TIME_PATTERN)
+
+
 def objetize(klass, client, data, handlers={}, methods=[], path=None):
     """Transform the :data: object into an object with class :klass:."""
     if data is None:
         return None
-    if klass in [str, int, dict, bool, parser.isoparse]:
+    if klass in [str, int, dict, bool, objetize_datetime]:
         return klass(data)
     return klass(client, handlers, methods, path, **data)
 

--- a/fintoc/utils.py
+++ b/fintoc/utils.py
@@ -79,7 +79,7 @@ def serialize(object_):
     if callable(getattr(object_, "serialize", None)):
         return object_.serialize()
     if isinstance(object_, datetime.datetime):
-        return object_.isoformat()
+        return object_.strftime(DATE_TIME_PATTERN)
     return object_
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -387,17 +387,6 @@ toml = "*"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
-name = "python-dateutil"
-version = "2.8.2"
-description = "Extensions to the standard Python datetime module"
-category = "main"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-
-[package.dependencies]
-six = ">=1.5"
-
-[[package]]
 name = "regex"
 version = "2021.8.3"
 description = "Alternative regular expression module, to replace re."
@@ -418,14 +407,6 @@ idna = {version = "*", optional = true, markers = "extra == \"idna2008\""}
 
 [package.extras]
 idna2008 = ["idna"]
-
-[[package]]
-name = "six"
-version = "1.16.0"
-description = "Python 2 and 3 compatibility utilities"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "sniffio"
@@ -485,7 +466,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "b9ffc636c7d1190f961df9bd23472bfc47b48931309127634072e7f87bf789bb"
+content-hash = "36342eb6dab47343d0339b7a3c4c08d8791860149e3181010443c8288fee292e"
 
 [metadata.files]
 appdirs = [
@@ -705,10 +686,6 @@ pytest-cov = [
     {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
     {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
 ]
-python-dateutil = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
-]
 regex = [
     {file = "regex-2021.8.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8764a78c5464ac6bde91a8c87dd718c27c1cabb7ed2b4beaf36d3e8e390567f9"},
     {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4551728b767f35f86b8e5ec19a363df87450c7376d7419c3cac5b9ceb4bce576"},
@@ -747,10 +724,6 @@ regex = [
 rfc3986 = [
     {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
     {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
-]
-six = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 sniffio = [
     {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ exclude = [
 [tool.poetry.dependencies]
 python = "^3.6"
 httpx = ">=0.16, < 1.0"
-python-dateutil = ">=2.8, < 3.0"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"


### PR DESCRIPTION
## Description

This Pull Request pulls back the punches of the datetime parser, by explicitly telling it the exact form of the datetime strings that the SDK can receive.

Closes #42.

## Requirements

None.

## Additional changes

Removed the `dateutil` dependency.
