### PR TITLE
Support two date formats

### DIFF
--- a/fintoc/constants.py
+++ b/fintoc/constants.py
@@ -4,4 +4,4 @@ API_BASE_URL = "https://api.fintoc.com"
 API_VERSION = "v1"
 
 LINK_HEADER_PATTERN = r'<(?P<url>.*)>;\s*rel="(?P<rel>.*)"'
-DATE_TIME_PATTERN = "%Y-%m-%dT%H:%M:%S.%fZ"
+DATE_TIME_PATTERN = "%Y-%m-%dT%H:%M:%SZ"

--- a/fintoc/utils.py
+++ b/fintoc/utils.py
@@ -28,7 +28,13 @@ def is_iso_datetime(string):
         datetime.datetime.strptime(string, DATE_TIME_PATTERN)
         return True
     except ValueError:
-        return False
+        pass
+    try:
+        datetime.datetime.strptime(string, "%Y-%m-%dT%H:%M:%S.%fZ")
+        return True
+    except ValueError:
+        pass
+    return False
 
 
 def get_resource_class(snake_resource_name, value={}):
@@ -84,7 +90,10 @@ def serialize(object_):
 
 def objetize_datetime(string):
     """Objetizes a datetime string without checking for correctness."""
-    return datetime.datetime.strptime(string, DATE_TIME_PATTERN)
+    try:
+        return datetime.datetime.strptime(string, DATE_TIME_PATTERN)
+    except ValueError:
+        return datetime.datetime.strptime(string, "%Y-%m-%dT%H:%M:%S.%fZ")
 
 
 def objetize(klass, client, data, handlers={}, methods=[], path=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,8 +57,12 @@ class TestSingularize:
 
 class TestIsISODateTime:
     def test_valid_iso_format(self):
-        valid_iso_datetime_string = "2021-08-13T13:40:40.811Z"
+        valid_iso_datetime_string = "2021-08-13T13:40:40Z"
         assert is_iso_datetime(valid_iso_datetime_string)
+
+    def test_valid_iso_miliseconds_format(self):  # TEMPORARY
+        valid_iso_miliseconds_datetime_string = "2021-08-13T13:40:40.811Z"
+        assert is_iso_datetime(valid_iso_miliseconds_datetime_string)
 
     def test_invalid_iso_string_format(self):
         invalid_iso_datetime_string = "This is not a date"
@@ -219,12 +223,17 @@ class TestObjetize:
 
 class TestObjetizeDateTime:
     def setup_method(self):
-        self.valid_string = "2021-12-16T12:24:44.397000Z"
+        self.valid_string = "2021-12-16T12:24:44Z"
+        self.valid_miliseconds_string = "2021-12-16T12:24:44.397Z"
         self.obviously_invalid_string = "This is not a date"
         self.deceptively_invalid_string = "1105122"
 
     def test_valid_string(self):
         parsed = objetize_datetime(self.valid_string)
+        assert isinstance(parsed, datetime.datetime)
+
+    def test_valid_miliseconds_string(self):  # TEMPORARY
+        parsed = objetize_datetime(self.valid_miliseconds_string)
         assert isinstance(parsed, datetime.datetime)
 
     def test_obviously_invalid_string(self):


### PR DESCRIPTION
## Description

Add support for datetimes with and without miliseconds using these template strings:

- `%Y-%m-%dT%H:%M:%SZ` (no miliseconds)
- `%Y-%m-%dT%H:%M:%S.%fZ` (miliseconds)

Code might be a bit junky (on purpose) for the miliseconds part, as it is supposed to be a temporary fix until the API standardizes its datetime format (which should happen shortly to the former of both formats presented previously).

## Requirements

None.

## Additional changes

None.
