### PR TITLE
Correctly checkout code on CI/CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout to commit code
+        uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Description

Se cayó el deploy de esto hace mucho tiempo y no nos habíamos dado cuenta :hide-the-pain-dani:. Faltaba la acción para hacer checkout, ahora sí está.

## Requirements

None.

## Additional changes

None.
