### PR TITLE
Fix http error decorator

### DIFF
--- a/fintoc/mixins/manager_mixin.py
+++ b/fintoc/mixins/manager_mixin.py
@@ -3,7 +3,7 @@
 from abc import ABCMeta, abstractmethod
 
 from fintoc.resource_handlers import resource_all, resource_create, resource_get
-from fintoc.utils import can_raise_http_error, get_resource_class
+from fintoc.utils import can_raise_fintoc_error, get_resource_class
 
 
 class ManagerMixin(metaclass=ABCMeta):  # pylint: disable=no-self-use
@@ -44,7 +44,7 @@ class ManagerMixin(metaclass=ABCMeta):  # pylint: disable=no-self-use
         one of: ['all', 'get', 'create', 'update', 'delete'].
         """
 
-    @can_raise_http_error
+    @can_raise_fintoc_error
     def _all(self, **kwargs):
         """
         Return all instances of the resource being handled by the manager.
@@ -61,7 +61,7 @@ class ManagerMixin(metaclass=ABCMeta):  # pylint: disable=no-self-use
         )
         return self.post_all_handler(objects, **kwargs)
 
-    @can_raise_http_error
+    @can_raise_fintoc_error
     def _get(self, identifier, **kwargs):
         """
         Return an instance of the resource being handled by the manager,
@@ -79,7 +79,7 @@ class ManagerMixin(metaclass=ABCMeta):  # pylint: disable=no-self-use
         )
         return self.post_get_handler(object_, identifier, **kwargs)
 
-    @can_raise_http_error
+    @can_raise_fintoc_error
     def _create(self, **kwargs):
         """
         Create an instance of the resource being handled by the manager.
@@ -96,7 +96,7 @@ class ManagerMixin(metaclass=ABCMeta):  # pylint: disable=no-self-use
         )
         return self.post_create_handler(object_, **kwargs)
 
-    @can_raise_http_error
+    @can_raise_fintoc_error
     def _update(self, identifier, **kwargs):
         """
         Update an instance of the resource being handled by the manager,
@@ -106,7 +106,7 @@ class ManagerMixin(metaclass=ABCMeta):  # pylint: disable=no-self-use
         object_ = self._get(identifier)
         return object_.update(**kwargs)
 
-    @can_raise_http_error
+    @can_raise_fintoc_error
     def _delete(self, identifier, **kwargs):
         """
         Delete an instance of the resource being handled by the manager,

--- a/fintoc/mixins/resource_mixin.py
+++ b/fintoc/mixins/resource_mixin.py
@@ -4,7 +4,7 @@ from abc import ABCMeta
 
 from fintoc.resource_handlers import resource_delete, resource_update
 from fintoc.utils import (
-    can_raise_http_error,
+    can_raise_fintoc_error,
     get_resource_class,
     objetize,
     serialize,
@@ -60,7 +60,7 @@ class ResourceMixin(metaclass=ABCMeta):
             serialized = {**serialized, key: element}
         return serialized
 
-    @can_raise_http_error
+    @can_raise_fintoc_error
     def _update(self, **kwargs):
         id_ = getattr(self, self.__class__.resource_identifier)
         object_ = resource_update(
@@ -76,7 +76,7 @@ class ResourceMixin(metaclass=ABCMeta):
         self.__dict__.update(object_.__dict__)
         return self
 
-    @can_raise_http_error
+    @can_raise_fintoc_error
     def _delete(self, **kwargs):
         identifier = getattr(self, self.__class__.resource_identifier)
         resource_delete(

--- a/fintoc/utils.py
+++ b/fintoc/utils.py
@@ -64,14 +64,14 @@ def get_error_class(snake_error_name):
 
 def can_raise_fintoc_error(function):
     """
-    Decorator that catches HTTPError exceptions and raises custom
+    Decorator that catches HTTPStatusError exceptions and raises custom
     Fintoc errors instead.
     """
 
     def wrapper(*args, **kwargs):
         try:
             return function(*args, **kwargs)
-        except httpx.HTTPError as exc:
+        except httpx.HTTPStatusError as exc:
             error_data = exc.response.json()
             error = get_error_class(error_data["error"]["type"])
             raise error(error_data["error"]) from None

--- a/fintoc/utils.py
+++ b/fintoc/utils.py
@@ -62,7 +62,7 @@ def get_error_class(snake_error_name):
     return getattr(module, snake_to_pascal(snake_error_name), FintocError)
 
 
-def can_raise_http_error(function):
+def can_raise_fintoc_error(function):
     """
     Decorator that catches HTTPError exceptions and raises custom
     Fintoc errors instead.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ from fintoc.constants import DATE_TIME_PATTERN
 from fintoc.errors import ApiError, FintocError
 from fintoc.resources import GenericFintocResource, Link
 from fintoc.utils import (
-    can_raise_http_error,
+    can_raise_fintoc_error,
     get_error_class,
     get_resource_class,
     is_iso_datetime,
@@ -117,7 +117,7 @@ class TestGetErrorClass:
         assert error is FintocError
 
 
-class TestCanRaiseHTTPError:
+class TestCanRaiseFintocError:
     @pytest.fixture(autouse=True)
     def patch_http_error(self, patch_http_error):
         pass
@@ -126,28 +126,28 @@ class TestCanRaiseHTTPError:
         def no_error():
             pass
 
-        def raise_http_error():
             raise httpx.HTTPError("F")
+        def raise_http_status_error():
 
         def raise_generic_error():
             raise ValueError("Not HTTP Error")
 
         self.no_error = no_error
-        self.raise_http_error = raise_http_error
+        self.raise_http_status_error = raise_http_status_error
         self.raise_generic_error = raise_generic_error
 
     def test_no_error(self):
-        wrapped = can_raise_http_error(self.no_error)
+        wrapped = can_raise_fintoc_error(self.no_error)
         wrapped()
 
-    def test_http_error(self):
-        wrapped = can_raise_http_error(self.raise_http_error)
+    def test_http_status_error(self):
+        wrapped = can_raise_fintoc_error(self.raise_http_status_error)
         with pytest.raises(Exception) as execinfo:
             wrapped()
         assert isinstance(execinfo.value, FintocError)
 
     def test_generic_error(self):
-        wrapped = can_raise_http_error(self.raise_generic_error)
+        wrapped = can_raise_fintoc_error(self.raise_generic_error)
         with pytest.raises(Exception) as execinfo:
             wrapped()
         assert not isinstance(execinfo.value, FintocError)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,14 +126,24 @@ class TestCanRaiseFintocError:
         def no_error():
             pass
 
-            raise httpx.HTTPError("F")
         def raise_http_status_error():
+            raise httpx.HTTPStatusError(
+                message="HTTP Status Error",
+                response=httpx.Response(
+                    status_code=400, json={"error": {"type": "api_error"}}
+                ),
+                request=httpx.Request("GET", "/"),
+            )
+
+        def raise_connect_error():
+            raise httpx.ConnectError(message="Connection Error")
 
         def raise_generic_error():
             raise ValueError("Not HTTP Error")
 
         self.no_error = no_error
         self.raise_http_status_error = raise_http_status_error
+        self.raise_connect_error = raise_connect_error
         self.raise_generic_error = raise_generic_error
 
     def test_no_error(self):
@@ -145,6 +155,12 @@ class TestCanRaiseFintocError:
         with pytest.raises(Exception) as execinfo:
             wrapped()
         assert isinstance(execinfo.value, FintocError)
+
+    def test_connect_error(self):
+        wrapped = can_raise_fintoc_error(self.raise_connect_error)
+        with pytest.raises(Exception) as execinfo:
+            wrapped()
+        assert not isinstance(execinfo.value, FintocError)
 
     def test_generic_error(self):
         wrapped = can_raise_fintoc_error(self.raise_generic_error)


### PR DESCRIPTION
## Description

Este PR permite obtener los mensajes de error de la librería `httpx` cuando no son de tipo `httpx.HTTPStatusError`. Hasta el momento solo se atrapaba el error `httpx.HTTPError`, pero este era poco específico y fallaba cuando el error traía el atributo `.response` (el cual solo tiene `httpx.HTTPStatusError`).

Se aprovecha de renombrar el decorador `can_raise_http_error` a `can_raise_fintoc_error`, ya que es más correcto.

## Requirements

None.

## Additional changes

None.
