### PR TITLE
pre-release: prepare 2.4.1 release

### DIFF
--- a/fintoc/version.py
+++ b/fintoc/version.py
@@ -1,4 +1,4 @@
 """Module to hold the version utilities."""
 
-version_info = (2, 4, 0)
+version_info = (2, 4, 1)
 __version__ = ".".join([str(x) for x in version_info])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fintoc"
-version = "2.4.0"
+version = "2.4.1"
 description = "The official Python client for the Fintoc API."
 authors = ["Daniel Leal <daniel@fintoc.com>", "Nebil Kawas <nebil@uc.cl>"]
 maintainers = ["Daniel Leal <daniel@fintoc.com>"]


### PR DESCRIPTION
## Description

- Se corrige catch del error de `can_raise_http_error` y se cambia `httpx.HTTPStatusError`.

## Requirements

None.

## Additional changes

- Se renombra el decorador `can_raise_http_error` a `can_raise_fintoc_error`.
