### PR TITLE
Chore: set ubuntu-latest as github actions runner image

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   black:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout to commit code
         uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
         run: make black
 
   flake8:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout to commit code
         uses: actions/checkout@v3
@@ -73,7 +73,7 @@ jobs:
         run: make flake8
 
   isort:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout to commit code
         uses: actions/checkout@v3
@@ -103,7 +103,7 @@ jobs:
         run: make isort
 
   pylint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout to commit code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pypi-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout to commit code
         uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
   github-release:
     needs: pypi-release
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout to commit code
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout to commit code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

`ubuntu-20.04` is deprecated and our github actions were not running. This PR updates the ubuntu image.

For more information see: https://github.com/actions/runner-images/issues/11101

## Requirements

None.

## Additional changes

None.
