### PR TITLE
Add base managers for all endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,25 +28,12 @@
 - [Installation](#installation)
 - [Usage](#usage)
   - [Quickstart](#quickstart)
-  - [Managers](#managers)
+  - [Calling endpoints](#calling-endpoints)
     - [all](#all)
     - [get](#get)
     - [create](#create)
     - [update](#update)
     - [delete](#delete)
-  - [The shape of the SDK](#the-shape-of-the-sdk)
-    - [The `Fintoc` object](#the-fintoc-object)
-    - [The `webhook_endpoints` manager](#the-webhook_endpoints-manager)
-    - [The `payment_intents` manager](#the-payment_intents-manager)
-    - [The `links` manager](#the-links-manager)
-    - [The `invoices` manager](#the-invoices-manager)
-    - [The `tax_returns` manager](#the-tax_returns-manager)
-    - [The `refresh_intents` manager](#the-refresh_intents-manager)
-    - [The `accounts` manager](#the-accounts-manager)
-    - [The `movements` manager](#the-movements-manager)
-    - [The `subscription_intents` manager](#the-subscription_intents-manager)
-    - [The `subscriptions` manager](#the-subscriptions-manager)
-    - [The `charges` manager](#the-charges-manager)
   - [Webhook Signature Validation](#webhook-signature-validation)
   - [Serialization](#serialization)
 - [Acknowledgements](#acknowledgements)
@@ -67,376 +54,96 @@ The idea behind this SDK is to stick to the API design as much as possible, so t
 
 ### Quickstart
 
-To be able to use this SDK, you first need to have a [Fintoc](https://app.fintoc.com/login) account. You will need to get your secret API key from the dashboard to be able to use the SDK. Once you have your API key, all you need to do is initialize a `Fintoc` object with it and you're ready to start enjoying Fintoc!
+To be able to use this SDK, you first need to get your secret API Key from the [Fintoc Dashboard](https://dashboard.fintoc.com/login). Once you have your API key, all you need to do is initialize a `Fintoc` object with it and you're ready to start enjoying Fintoc!
 
 ```python
 from fintoc import Fintoc
 
-fintoc_client = Fintoc("your_api_key")
+client = Fintoc("your_api_key")
+
+# list all succeeded payment intents since the beginning of 2025
+payment_intents = client.payment_intents.all(since="2025-01-01", status="succeeded")
+for pi in payment_intents:
+    print(pi.created_at, pi.amount, pi.customer_email)
+
+# Get a specific payment intent
+payment_intent = client.payment_intents.get("pi_12345235412")
+print(payment_intent.customer_email)
 ```
 
-Now you can start using the SDK!
+### Calling endpoints
 
-### Managers
+The SDK provides direct access to Fintoc API resources following the API structure. Simply use the resource name and follow it by the appropriate action you want.
 
-To make the usage of the SDK feel natural, resources are managed by **managers** (_wow_). These **managers** correspond to objects with some methods that allow you to get the resources that you want. Each manager is _attached_ to another resource, following the API structure. For example, the `Fintoc` object has `links` and `webhook_endpoints` managers, while `Link` objects have an `accounts` manager (we will see more examples soon). Notice that **not every manager has all of the methods**, as they correspond to the API capabilities. The methods of the managers are the following (we will use the `webhook_endpoints` manager as an example):
+Notice that **not every resource has all of the methods**, as they correspond to the API capabilities.
 
 #### `all`
 
-You can use the `all` method of the managers as follows:
+You can use the `all` method to list all the instances of the resource:
 
 ```python
-webhook_endpoints = fintoc_client.webhook_endpoints.all()
+webhook_endpoints = client.webhook_endpoints.all()
 ```
 
-The `all` method of the managers returns **a generator** with all the instances of the resource. This method can also receive `kwargs`! The arguments that can be passed are the arguments that the API receives for that specific resource! For example, the `Movement` resource can be filtered using `since` and `until`, so if you wanted to get a range of `movements` from an `account`, all you need to do is to pass the parameters to the method!
+The `all` method returns **a generator** with all the instances of the resource. This method can also receive the arguments that the API receives for that specific resource. For example, the `PaymentIntent` resource can be filtered using `since` and `until`, so if you wanted to get a range of `payment intents`, all you need to do is to pass the parameters to the method:
 
 ```python
-movements = account.movements.all(since="2019-07-24", until="2021-05-12")
+payment_intents = client.payment_intents.all(since="2025-01-01", until="2025-02-01")
 ```
 
 You can also pass the `lazy=False` parameter to the method to force the SDK to return a list of all the instances of the resource instead of the generator. **Beware**: this could take **very long**, depending on the amount of instances that exist of said resource:
 
 ```python
-webhook_endpoints = fintoc_client.webhook_endpoints.all(lazy=False)
+payment_intents = client.payment_intents.all(since="2025-01-01", until="2025-02-01", lazy=False)
 
-isinstance(webhook_endpoints, list)  # True
+isinstance(payment_intents, list)  # True
 ```
 
 #### `get`
 
-You can use the `get` method of the managers as follows:
+You can use the `get` method to get a specific instance of the resource:
 
 ```python
-webhook_endpoint = fintoc_client.webhook_endpoints.get("we_8anqVLlBC8ROodem")
+payment_intent = client.payment_intents.get("pi_8anqVLlBC8ROodem")
 ```
-
-The `get` method of the managers returns an existing instance of the resource using its identifier to find it.
 
 #### `create`
 
-You can use the `create` method of the managers as follows:
+You can use the `create` method to create an instance of the resource:
 
 ```python
-webhook_endpoint = fintoc_client.webhook_endpoints.create(
+webhook_endpoint = client.webhook_endpoints.create(
     url="https://webhook.site/58gfb429-c33c-20c7-584b-d5ew3y3202a0",
     enabled_events=["link.credentials_changed"],
     description="Fantasting webhook endpoint",
 )
 ```
 
-The `create` method of the managers creates and returns a new instance of the resource. The attributes of the created object are passed as `kwargs`, and correspond to the parameters specified by the API documentation for the creation of said resource.
+The `create` method of the managers creates and returns a new instance of the resource. The attributes used for creating the object are passed as `kwargs`, and correspond to the parameters specified by the API documentation for the creation of said resource.
 
 #### `update`
 
-You can use the `update` method of the managers as follows:
+You can use the `update` method to update an instance of the resource:
 
 ```python
-webhook_endpoint = fintoc_client.webhook_endpoints.update(
+webhook_endpoint = client.webhook_endpoints.update(
     "we_8anqVLlBC8ROodem",
     enabled_events=["account.refresh_intent.succeeded"],
     disabled=True,
 )
 ```
 
-The `update` method of the managers updates and returns an existing instance of the resource using its identifier to find it. The first parameter of the method corresponds to the identifier being used to find the existing instance of the resource. The attributes to be modified are passed as `kwargs`, and correspond to the parameters specified by the API documentation for the update action of said resource.
-
-Notice that using the manager to update an instance of a resource is equivalent (in terms of outcome) to calling the `update` directly on the object itself:
-
-
-```python
-# Using the manager
-webhook_endpoint = fintoc_client.webhook_endpoints.update(
-    "we_8anqVLlBC8ROodem",
-    enabled_events=["account.refresh_intent.succeeded"],
-    disabled=True,
-)
-
-# Using the object
-webhook_endpoint = fintoc_client.webhook_endpoints.get("we_8anqVLlBC8ROodem")
-webhook_endpoint.update(
-    enabled_events=["account.refresh_intent.succeeded"],
-    disabled=True,
-)
-```
-
-When using the SDK, you will probably almost always want to use the object directly to update, just because it is way less verbose if you already have the object itself. Also, using the `update` method from the manager first needs to `get` the resource and then updates it, so it translates to 2 API calls. If you already have the object to update, using the `update` method directly from the object just updates it, so it translates to just 1 API call.
+The `update` method updates and returns an existing instance of the resource using its identifier to find it. The first parameter of the method corresponds to the identifier being used to find the existing instance of the resource. The attributes to be modified are passed as `kwargs`, and correspond to the parameters specified by the API documentation for the update action of said resource.
 
 #### `delete`
 
-You can use the `delete` method of the managers as follows:
+You can use the `delete` method to delete an instance of the resource:
 
 ```python
-deleted_identifier = fintoc_client.webhook_endpoints.delete("we_8anqVLlBC8ROodem")
+deleted_identifier = client.webhook_endpoints.delete("we_8anqVLlBC8ROodem")
 ```
 
-The `delete` method of the managers deletes an existing instance of the resource using its identifier to find it and returns the identifier.
-
-Notice that using the manager to delete an instance of a resource is equivalent (in terms of outcome) to calling the `delete` directly on the object itself:
-
-
-```python
-# Using the manager
-deleted_identifier = fintoc_client.webhook_endpoints.delete("we_8anqVLlBC8ROodem")
-
-# Using the object
-webhook_endpoint = fintoc_client.webhook_endpoints.get("we_8anqVLlBC8ROodem")
-deleted_identifier = webhook_endpoint.delete()
-```
-
-When using the SDK, you will probably almost always want to use the object directly to delete, just because it is way less verbose if you already have the object itself. Also, using the `delete` method from the manager first needs to `get` the resource and then deletes it, so it translates to 2 API calls. If you already have the object to delete, using the `delete` method directly from the object just deletes it, so it translates to just 1 API call.
-
-### The shape of the SDK
-
-For complete information about the API, head to [the docs](https://fintoc.com/docs). You will notice that the shape of the SDK is very similar to the shape of the API. Let's start with the `Fintoc` object.
-
-#### The `Fintoc` object
-
-To create a `Fintoc` object, instantiate it using your secret API key:
-
-```python
-from fintoc import Fintoc
-
-fintoc_client = Fintoc("your_api_key")
-```
-
-This gives us access to a bunch of operations already. The object created using this _snippet_ contains three [managers](#managers): `links`, `payment_intents` and `webhook_endpoints`.
-
-#### The `webhook_endpoints` manager
-
-Available methods: `all`, `get`, `create`, `update`, `delete`.
-
-From the Fintoc client, you can manage your webhook endpoints swiftly! Start by creating a new Webhook Endpoint!
-
-```python
-webhook_endpoint = fintoc_client.webhook_endpoints.create(
-    url="https://webhook.site/58gfb429-c33c-20c7-584b-d5ew3y3202a0",
-    enabled_events=["account.refresh_intent.succeeded"],
-    disabled=True,
-)
-
-print(webhook_endpoint.id)  # we_8anqVLlBC8ROodem
-```
-
-You can update this webhook endpoint any time you want! Just run the following command:
-
-```python
-webhook_endpoint = fintoc_client.webhook_endpoints.update(
-    "we_8anqVLlBC8ROodem",
-    enabled_events=["link.credentials_changed"],
-    description="Fantasting webhook endpoint",
-)
-
-print(webhook_endpoint.status)  # disabled
-```
-
-Maybe you no longer want this webhook endpoint. Let's delete it!
-
-```python
-fintoc_client.webhook_endpoints.delete("we_8anqVLlBC8ROodem")
-```
-
-Now, let's list every webhook endpoint we have:
-
-```python
-for webhook_endpoint in fintoc_client.webhook_endpoints.all():
-    print(webhook_endpoint.id)
-```
-
-If you see a webhook endpoint you want to use, just use the `get` method!
-
-```python
-webhook_endpoint = fintoc_client.webhook_endpoints.get("we_8anqVLlBC8ROodem")
-
-print(webhook_endpoint.id)  # we_8anqVLlBC8ROodem
-```
-
-#### The `payment_intents` manager
-
-Available methods: `all`, `get`, `create`.
-
-Payment intents allow you to start a payment using Fintoc! Start by creating a new payment intent:
-
-```python
-payment_intent = fintoc_client.payment_intents.create(
-    currency="CLP",
-    amount=5990,
-    recipient_account={
-        "holder_id": "111111111",
-        "number": "123123123",
-        "type": "checking_account",
-        "institution_id": "cl_banco_de_chile",
-    }
-)
-
-print(payment_intent.id)            # pi_BO381oEATXonG6bj
-print(payment_intent.widget_token)  # pi_BO381oEATXonG6bj_sec_a4xK32BanKWYn
-```
-
-Notice that the success of this payment intent will be notified through a Webhook. Now, let's list every payment intent we have:
-
-```python
-for payment_intent in fintoc_client.payment_intents.all():
-    print(payment_intent.id)
-```
-
-If you see a payment intent you want to use, just use the `get` method!
-
-```python
-payment_intent = fintoc_client.payment_intents.get("pi_BO381oEATXonG6bj")
-
-print(payment_intent.id)      # pi_BO381oEATXonG6bj
-print(payment_intent.status)  # succeeded
-```
-
-#### The `links` manager
-
-Available methods: `all`, `get`, `update`, `delete`.
-
-Links are probably the most importat resource. Let's list them!
-
-```python
-print(len(fintoc_client.links.all(lazy=False)))  # 3
-
-for link in fintoc_client.links.all():
-    print(link.id)
-```
-
-Links are a bit different than the rest of the resources, because their identifier is not really their `id`, but their `link_token`. This means that, in order to `get`, `update` or `delete` a link, you need to pass the `link_token`!
-
-```python
-link = fintoc_client.links.get("link_Y75EXAKiIVj7w489_token_NCqjwRVoTX3cmnx8pnbpqd11")
-```
-
-Notice that the Link objects generated from the `all` method will won't be able to execute `update` or `delete` operations, while any Link object generated from `get` or `update` will have permission to `update` or `delete` (given that the link token is necessary to `get` or `update` in the first place).
-
-The Link resource has a lot of **managers**!
-
-```python
-invoices = link.invoices.all()  # Invoices
-tax_returns = link.tax_returns.all()  # Tax Returns
-subscriptions = link.subscriptions.all()  # Subscriptions
-refresh_intents = link.refresh_intents.all()  # Refresh Intents
-accounts = link.accounts.all()  # Accounts
-```
-
-#### The `invoices` manager
-
-Available methods: `all`.
-
-Once you have a Link, you can use the `invoices` manager to get all the invoices associated to a link!
-
-```python
-for invoice in link.invoices.all():
-    print(invoice.id)
-```
-
-#### The `tax_returns` manager
-
-Available methods: `all`, `get`.
-
-Once you have a Link, you can use the `tax_returns` manager to get all the tax returns associated to a link!
-
-```python
-for tax_return in link.tax_returns.all():
-    print(tax_return.id)
-```
-
-#### The `refresh_intents` manager
-
-Available methods: `all`, `get`, `create`.
-
-Refresh intents allow you to control how an account gets refreshed on Fintoc! Once you have a Link, you can use the `refresh_intents` manager to create a new refresh intent:
-
-```python
-refresh_intent = link.refresh_intents.create()
-
-print(refresh_intent.id)  # ri_5A94DVCJ7xNM3MEo
-```
-
-Notice that the success of this refresh intent will be notified through a Webhook. Now, let's list every refresh intent we have:
-
-```python
-for refresh_intent in link.refresh_intents.all():
-    print(refresh_intent.id)
-```
-
-If you see a refresh intent you want to use, just use the `get` method!
-
-```python
-refresh_intent = link.refresh_intents.get("ri_5A94DVCJ7xNM3MEo")
-
-print(refresh_intent.id)      # ri_5A94DVCJ7xNM3MEo
-print(refresh_intent.status)  # succeeded
-```
-
-#### The `accounts` manager
-
-Available methods: `all`, `get`.
-
-Once you have a Link, you can use the `accounts` manager to get all the accounts associated to a link!
-
-```python
-for account in link.accounts.all():
-    print(account.id)
-```
-
-Notice that accounts also have a `movements` manager, to get all of the movements of an account:
-
-```python
-account = link.accounts.all(lazy=False)[0]
-
-movements = account.movements.all(lazy=False)
-```
-
-#### The `movements` manager
-
-Available methods: `all`, `get`.
-
-Once you have an Account, you can use the `movements` manager to get all the movements associated to that account!
-
-```python
-for movement in account.movements.all():
-    print(movement.id)
-```
-
-#### The `subscription_intents` manager
-
-Available methods: `all`, `get`, `create`
-
-Subscription intents allow you to start a subscription using Fintoc!:
-
-```python
-subscription_intent = fintoc_client.subscription_intents.create()
-
-print(subscription_intent.id)            # si_BO381oEATXonG6bj
-print(subscription_intent.widget_token)  # si_BO381oEATXonG6bj_sec_a4xK32BanKWYn
-```
-
-#### The `subscriptions` manager
-
-Available methods: `all`, `get`
-
-You can check the status of the created subscription with the `subscriptions` manager
-
-```python
-subscription = fintoc_client.subscriptions.get('<subscription_id>')
-print(subscription.status)
-```
-
-#### The `charges` manager
-
-Available methods: `all`, `get`, `create`
-
-Once you have active subscriptions, you can use the `charges` manager to create charges to thosse subscriptions
-
-```python
-charge = fintoc_client.charges.create(
-    currency='CLP',
-    amount=1250,
-    subscription_id='<subscription_id>',
-)
-```
+The `delete` method deletes an existing instance of the resource using its identifier to find it and returns the identifier.
 
 ### Webhook Signature Validation
 
@@ -458,7 +165,6 @@ The `verify_header` method takes the following parameters:
 
 If the signature is invalid or the timestamp is outside the tolerance window, a `WebhookSignatureError` will be raised with a descriptive message.
 
-
 For a complete example of handling webhooks, see [examples/webhook.py](examples/webhook.py).
 
 ### Serialization
@@ -466,9 +172,9 @@ For a complete example of handling webhooks, see [examples/webhook.py](examples/
 Any resource of the SDK can be serialized! To get the serialized resource, just call the `serialize` method!
 
 ```python
-account = link.accounts.all(lazy=False)[0]
+payment_intent = client.payment_intents.all(lazy=False)[0]
 
-serialization = account.serialize()
+serialization = payment_intent.serialize()
 ```
 
 The serialization corresponds to a dictionary with only simple types, that can be JSON-serialized.

--- a/fintoc/core.py
+++ b/fintoc/core.py
@@ -9,7 +9,6 @@ from fintoc.managers import (
     ChargesManager,
     InvoicesManager,
     LinksManager,
-    MovementsManager,
     PaymentIntentsManager,
     RefreshIntentsManager,
     SubscriptionIntentsManager,
@@ -46,6 +45,3 @@ class Fintoc:
         self.refresh_intents = RefreshIntentsManager("/refresh_intents", self._client)
         self.tax_returns = TaxReturnsManager("/tax_returns", self._client)
         self.invoices = InvoicesManager("/invoices", self._client)
-        self.movements = MovementsManager(
-            "/accounts/{account_id}/movements", self._client
-        )

--- a/fintoc/core.py
+++ b/fintoc/core.py
@@ -5,17 +5,24 @@ Core module to house the Fintoc object of the Fintoc Python SDK.
 from fintoc.client import Client
 from fintoc.constants import API_BASE_URL, API_VERSION
 from fintoc.managers import (
+    AccountsManager,
     ChargesManager,
+    InvoicesManager,
     LinksManager,
+    MovementsManager,
     PaymentIntentsManager,
+    RefreshIntentsManager,
     SubscriptionIntentsManager,
     SubscriptionsManager,
+    TaxReturnsManager,
     WebhookEndpointsManager,
 )
 from fintoc.version import __version__
 
 
+# pylint: disable=too-many-instance-attributes
 class Fintoc:
+
     """Encapsulates the core object's behaviour and methods."""
 
     def __init__(self, api_key, api_version=None):
@@ -34,4 +41,11 @@ class Fintoc:
         )
         self.webhook_endpoints = WebhookEndpointsManager(
             "/webhook_endpoints", self._client
+        )
+        self.accounts = AccountsManager("/accounts", self._client)
+        self.refresh_intents = RefreshIntentsManager("/refresh_intents", self._client)
+        self.tax_returns = TaxReturnsManager("/tax_returns", self._client)
+        self.invoices = InvoicesManager("/invoices", self._client)
+        self.movements = MovementsManager(
+            "/accounts/{account_id}/movements", self._client
         )

--- a/fintoc/managers/accounts_manager.py
+++ b/fintoc/managers/accounts_manager.py
@@ -1,11 +1,31 @@
 """Module to hold the accounts manager."""
 
+from fintoc.managers.movements_manager import MovementsManager
 from fintoc.mixins import ManagerMixin
 
 
+# pylint: disable=duplicate-code
 class AccountsManager(ManagerMixin):
 
     """Represents an accounts manager."""
 
     resource = "account"
     methods = ["all", "get"]
+
+    def __init__(self, path, client):
+        super().__init__(path, client)
+        self.__movements_manager = None
+
+    @property
+    def movements(self):
+        """Proxies the movements manager."""
+        if self.__movements_manager is None:
+            self.__movements_manager = MovementsManager(
+                "/accounts/{account_id}/movements",
+                self._client,
+            )
+        return self.__movements_manager
+
+    @movements.setter
+    def movements(self, new_value):  # pylint: disable=no-self-use
+        raise NameError("Attribute name corresponds to a manager")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -57,159 +57,261 @@ class TestFintocIntegration:
 
     def test_link_accounts_all(self):
         """Test getting accounts from a link."""
+
+        def assert_accounts(accounts):
+            assert len(accounts) > 0
+            for account in accounts:
+                assert account.method == "get"
+                assert account.url == "v1/accounts"
+                assert account.params.link_token == link_token
+
         link_token = "test_link_token"
+
+        # Test using the resource
         link = self.fintoc.links.get(link_token)
+        assert_accounts(list(link.accounts.all()))
 
-        accounts = list(link.accounts.all())
-
-        assert len(accounts) > 0
-        for account in accounts:
-            assert account.method == "get"
-            assert account.url == "v1/accounts"
-            assert account.params.link_token == link_token
+        # Test using directly the manager
+        assert_accounts(list(self.fintoc.accounts.all(link_token=link_token)))
 
     def test_link_account_get(self):
         """Test getting a specific account from a link."""
+
+        def assert_account(account):
+            assert account.method == "get"
+            assert account.params.link_token == link_token
+            assert account.url == f"v1/accounts/{account_id}"
+
         link_token = "test_link_token"
-        link = self.fintoc.links.get(link_token)
-
         account_id = "test_account_id"
-        account = link.accounts.get(account_id)
 
-        assert account.method == "get"
-        assert account.params.link_token == link_token
-        assert account.url == f"v1/accounts/{account_id}"
+        # Test using the resource
+        link = self.fintoc.links.get(link_token)
+        account = link.accounts.get(account_id)
+        assert_account(account)
+
+        # Test using directly the manager
+        account = self.fintoc.accounts.get(account_id, link_token=link_token)
+        assert_account(account)
 
     def test_account_movements_all(self):
         """Test getting movements from an account."""
+
+        def assert_movements(movements):
+            assert len(movements) > 0
+            for movement in movements:
+                assert movement.method == "get"
+                assert movement.url == f"v1/accounts/{account_id}/movements"
+                assert movement.params.link_token == link_token
+
         link_token = "test_link_token"
-        link = self.fintoc.links.get(link_token)
-
         account_id = "test_account_id"
+
+        # Test using the resource
+        link = self.fintoc.links.get(link_token)
         account = link.accounts.get(account_id)
+        assert_movements(list(account.movements.all()))
 
-        movements = list(account.movements.all())
-
-        assert len(movements) > 0
-        for movement in movements:
-            assert movement.method == "get"
-            assert movement.url == f"v1/accounts/{account.id}/movements"
-            assert movement.params.link_token == link_token
+        # Test using directly the manager
+        assert_movements(
+            list(
+                self.fintoc.movements.all(account_id=account_id, link_token=link_token)
+            )
+        )
 
     def test_account_movement_get(self):
         """Test getting a specific movement from an account."""
+
+        def assert_movement(movement):
+            assert movement.method == "get"
+            assert movement.url == f"v1/accounts/{account_id}/movements/{movement_id}"
+            assert movement.params.link_token == link_token
+
         link_token = "test_link_token"
-        link = self.fintoc.links.get(link_token)
-
         account_id = "test_account_id"
-        account = link.accounts.get(account_id)
-
         movement_id = "test_movement_id"
-        movement = account.movements.get(movement_id)
 
-        assert movement.method == "get"
-        assert movement.url == f"v1/accounts/{account.id}/movements/{movement_id}"
-        assert movement.params.link_token == link_token
+        # Test using the resource
+        link = self.fintoc.links.get(link_token)
+        account = link.accounts.get(account_id)
+        movement = account.movements.get(movement_id)
+        assert_movement(movement)
+
+        # Test using directly the manager
+        movement = self.fintoc.movements.get(
+            movement_id, account_id=account_id, link_token=link_token
+        )
+        assert_movement(movement)
 
     def test_link_subscriptions_all(self):
         """Test getting all subscriptions from a link."""
+
+        def assert_subscriptions(subscriptions):
+            assert len(subscriptions) > 0
+            for subscription in subscriptions:
+                assert subscription.method == "get"
+                assert subscription.url == "v1/subscriptions"
+
         link_token = "test_link_token"
+
+        # Test using the resource. This actually should be removed, because
+        # subscriptions do not depend on a link.
         link = self.fintoc.links.get(link_token)
+        assert_subscriptions(list(link.subscriptions.all()))
 
-        subscriptions = list(link.subscriptions.all())
-
-        assert len(subscriptions) > 0
-        for subscription in subscriptions:
-            assert subscription.method == "get"
-            assert subscription.url == "v1/subscriptions"
+        # Test using directly the manager
+        assert_subscriptions(list(self.fintoc.subscriptions.all()))
 
     def test_link_subscription_get(self):
         """Test getting a specific subscription from a link."""
+
+        def assert_subscription(subscription):
+            assert subscription.method == "get"
+            assert subscription.url == f"v1/subscriptions/{subscription_id}"
+
         link_token = "test_link_token"
-        link = self.fintoc.links.get(link_token)
-
         subscription_id = "test_subscription_id"
-        subscription = link.subscriptions.get(subscription_id)
 
-        assert subscription.method == "get"
-        assert subscription.url == f"v1/subscriptions/{subscription_id}"
+        # Test using the resource
+        link = self.fintoc.links.get(link_token)
+        subscription = link.subscriptions.get(subscription_id)
+        assert_subscription(subscription)
+
+        # Test using directly the manager
+        subscription = self.fintoc.subscriptions.get(
+            subscription_id, link_token=link_token
+        )
+        assert_subscription(subscription)
 
     def test_link_tax_returns_all(self):
         """Test getting all tax returns from a link."""
+
+        def assert_tax_returns(tax_returns):
+            assert len(tax_returns) > 0
+            for tax_return in tax_returns:
+                assert tax_return.method == "get"
+                assert tax_return.url == "v1/tax_returns"
+                assert tax_return.params.link_token == link_token
+
         link_token = "test_link_token"
+
+        # Test using the resource
         link = self.fintoc.links.get(link_token)
+        assert_tax_returns(list(link.tax_returns.all()))
 
-        tax_returns = list(link.tax_returns.all())
-
-        assert len(tax_returns) > 0
-        for tax_return in tax_returns:
-            assert tax_return.method == "get"
-            assert tax_return.url == "v1/tax_returns"
-            assert tax_return.params.link_token == link_token
+        # Test using directly the manager
+        assert_tax_returns(list(self.fintoc.tax_returns.all(link_token=link_token)))
 
     def test_link_tax_return_get(self):
         """Test getting a specific tax return from a link."""
+
+        def assert_tax_return(tax_return):
+            assert tax_return.method == "get"
+            assert tax_return.url == f"v1/tax_returns/{tax_return_id}"
+            assert tax_return.params.link_token == link_token
+
         link_token = "test_link_token"
-        link = self.fintoc.links.get(link_token)
-
         tax_return_id = "test_tax_return_id"
+
+        # Test using the resource
+        link = self.fintoc.links.get(link_token)
         tax_return = link.tax_returns.get(tax_return_id)
+        assert_tax_return(tax_return)
 
-        assert tax_return.method == "get"
-        assert tax_return.url == f"v1/tax_returns/{tax_return_id}"
-
-        assert tax_return.params.link_token == link_token
+        # Test using directly the manager
+        tax_return = self.fintoc.tax_returns.get(tax_return_id, link_token=link_token)
+        assert_tax_return(tax_return)
 
     def test_link_invoices_all(self):
         """Test getting all invoices from a link."""
+
+        def assert_invoices(invoices):
+            assert len(invoices) > 0
+            for invoice in invoices:
+                assert invoice.method == "get"
+                assert invoice.url == "v1/invoices"
+                assert invoice.params.link_token == link_token
+
         link_token = "test_link_token"
+
+        # Test using the resource
         link = self.fintoc.links.get(link_token)
+        assert_invoices(list(link.invoices.all()))
 
-        invoices = list(link.invoices.all())
-
-        assert len(invoices) > 0
-        for invoice in invoices:
-            assert invoice.method == "get"
-            assert invoice.url == "v1/invoices"
-            assert invoice.params.link_token == link_token
+        # Test using directly the manager
+        assert_invoices(list(self.fintoc.invoices.all(link_token=link_token)))
 
     def test_link_refresh_intents_all(self):
         """Test getting all refresh intents from a link."""
+
+        def assert_refresh_intents(refresh_intents):
+            assert len(refresh_intents) > 0
+            for refresh_intent in refresh_intents:
+                assert refresh_intent.method == "get"
+                assert refresh_intent.url == "v1/refresh_intents"
+                assert refresh_intent.params.link_token == link_token
+
         link_token = "test_link_token"
+
+        # Test using the resource
         link = self.fintoc.links.get(link_token)
+        assert_refresh_intents(list(link.refresh_intents.all()))
 
-        refresh_intents = list(link.refresh_intents.all())
-
-        assert len(refresh_intents) > 0
-        for refresh_intent in refresh_intents:
-            assert refresh_intent.method == "get"
-            assert refresh_intent.url == "v1/refresh_intents"
-            assert refresh_intent.params.link_token == link_token
+        # Test using directly the manager
+        assert_refresh_intents(
+            list(self.fintoc.refresh_intents.all(link_token=link_token))
+        )
 
     def test_link_refresh_intent_get(self):
         """Test getting a specific refresh intent from a link."""
+
+        def assert_refresh_intent(refresh_intent):
+            assert refresh_intent.method == "get"
+            assert refresh_intent.url == f"v1/refresh_intents/{refresh_intent_id}"
+            assert refresh_intent.params.link_token == link_token
+
         link_token = "test_link_token"
-        link = self.fintoc.links.get(link_token)
-
         refresh_intent_id = "test_refresh_intent_id"
+
+        # Test using the resource
+        link = self.fintoc.links.get(link_token)
         refresh_intent = link.refresh_intents.get(refresh_intent_id)
+        assert_refresh_intent(refresh_intent)
 
-        assert refresh_intent.method == "get"
-        assert refresh_intent.url == f"v1/refresh_intents/{refresh_intent_id}"
-
-        assert refresh_intent.params.link_token == link_token
+        # Test using directly the manager
+        refresh_intent = self.fintoc.refresh_intents.get(
+            refresh_intent_id, link_token=link_token
+        )
+        assert_refresh_intent(refresh_intent)
 
     def test_link_refresh_intent_create(self):
         """Test creating a refresh intent for a link."""
+
+        def assert_refresh_intent(refresh_intent):
+            assert refresh_intent.method == "post"
+            assert refresh_intent.url == "v1/refresh_intents"
+            assert refresh_intent.json.refresh_type == "only_last"
+            # Check link_token in either params or json
+            assert (
+                hasattr(refresh_intent.json, "link_token")
+                and refresh_intent.json.link_token == link_token
+            ) or (
+                hasattr(refresh_intent.params, "link_token")
+                and refresh_intent.params.link_token == link_token
+            )
+
         link_token = "test_link_token"
+
+        # Test using the resource
         link = self.fintoc.links.get(link_token)
-
         refresh_intent = link.refresh_intents.create(refresh_type="only_last")
+        assert_refresh_intent(refresh_intent)
 
-        assert refresh_intent.method == "post"
-        assert refresh_intent.url == "v1/refresh_intents"
-        assert refresh_intent.json.refresh_type == "only_last"
-        assert refresh_intent.params.link_token == link_token
+        # Test using directly the manager
+        refresh_intent = self.fintoc.refresh_intents.create(
+            refresh_type="only_last", link_token=link_token
+        )
+        assert_refresh_intent(refresh_intent)
 
     def test_charges_all(self):
         """Test getting all charges."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -115,7 +115,9 @@ class TestFintocIntegration:
         # Test using directly the manager
         assert_movements(
             list(
-                self.fintoc.movements.all(account_id=account_id, link_token=link_token)
+                self.fintoc.accounts.movements.all(
+                    account_id=account_id, link_token=link_token
+                )
             )
         )
 
@@ -138,7 +140,7 @@ class TestFintocIntegration:
         assert_movement(movement)
 
         # Test using directly the manager
-        movement = self.fintoc.movements.get(
+        movement = self.fintoc.accounts.movements.get(
             movement_id, account_id=account_id, link_token=link_token
         )
         assert_movement(movement)


### PR DESCRIPTION
## Description

This PR adds base managers for all endpoints. The objective is to stop using resource managers and instead use base managers always.

Example:

```python
# Deprecated this
link = client.links.get("link_123123_token_asdasd")
print(link.accounts.all(lazy=False)[0])

# Use this instead
print(client.accounts.all(link_token="link_123123_token_asdasd", lazy=False)[0])
```

Nested resources are called like this:

```python
# Deprecated this
link = client.links.get("link_123123_token_asdasd")
account = link.accounts.get("acc_1234324")
print(account.movements.all(lazy=False)[0])

# Use this instead
print(client.accounts.movements.all(
    account_id="acc_123412", 
    link_token="link_123123_token_asdasd, 
    lazy=False
))

```


Calling the resource managers is still available to maintain backwards compatibility, but I removed it from the documentation.

## Requirements

None.

## Additional changes

Rewrote the `README.md` to make it more concise, simpler and removed references to using resources to call API endpoints
