### PR TITLE
Feat/add transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,15 +206,17 @@ For a complete example of handling webhooks, see [examples/webhook.py](examples/
 Some endpoints need a [JWS Signature](https://docs.fintoc.com/docs/setting-up-jws-keys), in addition to your API Key, to verify the integrity and authenticity of API requests. To generate the signature, initialize the Fintoc client with the `jws_private_key` argument, and the SDK will handle the rest:
 
 ```python
+import os
+
 from fintoc import Fintoc
 
-# Use a path to the PEM file
+# Provide a path to your PEM file
 client = Fintoc("your_api_key", jws_private_key="private_key.pem")
 
-# Pass a string containing the PEM file
+# Or pass the PEM key directly as a string
 client = Fintoc("your_api_key", jws_private_key=os.environ.get('JWS_PRIVATE_KEY'))
 
-# Now you can create transfers
+# You can now create transfers securely
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@
     - [create](#create)
     - [update](#update)
     - [delete](#delete)
+    - [V2 Endpoints](#v2-endpoints)
+    - [Nested actions or resources](#nested-actions-or-resources)
   - [Webhook Signature Validation](#webhook-signature-validation)
+  - [Generate the JWS Signature](#gnerate-the-jws-signature)
   - [Serialization](#serialization)
 - [Acknowledgements](#acknowledgements)
 
@@ -145,6 +148,37 @@ deleted_identifier = client.webhook_endpoints.delete("we_8anqVLlBC8ROodem")
 
 The `delete` method deletes an existing instance of the resource using its identifier to find it and returns the identifier.
 
+#### v2 Endpoints
+
+To call v2 API endpoints, like the [Transfers API](https://docs.fintoc.com/reference/transfers), you need to prepend the resource name with the `v2` namespace, the same as the API does it:
+
+```python
+transfer = client.v2.transfers.create(
+        amount=49523,
+        currency="mxn",
+        account_id="acc_123545",
+        counterparty={
+                "account_number": "014180655091438298"
+            },
+        metadata={
+                "factura": '14814'
+            }
+        )
+
+```
+
+#### Nested actions or resources
+
+To call nested actions just call the method as it appears in the API. For example to [simulate receiving a transfer for the Transfers](https://docs.fintoc.com/reference/receive-an-inbound-transfer) product you can do:
+
+```python
+transfer = client.v2.simulate.receive_transfer(
+        amount=9912400,
+        currency="mxn",
+        account_number_id="acno_2vF18OHZdXXxPJTLJ5qghpo1pdU",
+        )
+```
+
 ### Webhook Signature Validation
 
 To ensure the authenticity of incoming webhooks from Fintoc, you should always validate the signature. The SDK provides a `WebhookSignature` class to verify the `Fintoc-Signature` header
@@ -166,6 +200,23 @@ The `verify_header` method takes the following parameters:
 If the signature is invalid or the timestamp is outside the tolerance window, a `WebhookSignatureError` will be raised with a descriptive message.
 
 For a complete example of handling webhooks, see [examples/webhook.py](examples/webhook.py).
+
+### Generate the JWS Signature
+
+Some endpoints need a [JWS Signature](https://docs.fintoc.com/docs/setting-up-jws-keys), in addition to your API Key, to verify the integrity and authenticity of API requests. To generate the signature, initialize the Fintoc client with the `jws_private_key` argument, and the SDK will handle the rest:
+
+```python
+from fintoc import Fintoc
+
+# Use a path to the PEM file
+client = Fintoc("your_api_key", jws_private_key="private_key.pem")
+
+# Pass a string containing the PEM file
+client = Fintoc("your_api_key", jws_private_key=os.environ.get('JWS_PRIVATE_KEY'))
+
+# Now you can create transfers
+```
+
 
 ### Serialization
 

--- a/fintoc/constants.py
+++ b/fintoc/constants.py
@@ -1,7 +1,6 @@
 """Module to hold the constants of the SDK."""
 
 API_BASE_URL = "https://api.fintoc.com"
-API_VERSION = "v1"
 
 LINK_HEADER_PATTERN = r'<(?P<url>.*)>;\s*rel="(?P<rel>.*)"'
 DATE_TIME_PATTERN = "%Y-%m-%dT%H:%M:%SZ"

--- a/fintoc/core.py
+++ b/fintoc/core.py
@@ -3,7 +3,7 @@ Core module to house the Fintoc object of the Fintoc Python SDK.
 """
 
 from fintoc.client import Client
-from fintoc.constants import API_BASE_URL, API_VERSION
+from fintoc.constants import API_BASE_URL
 from fintoc.managers import (
     AccountsManager,
     ChargesManager,
@@ -16,6 +16,9 @@ from fintoc.managers import (
     TaxReturnsManager,
     WebhookEndpointsManager,
 )
+from fintoc.managers.v2 import AccountNumbersManager
+from fintoc.managers.v2 import AccountsManager as AccountsManagerV2
+from fintoc.managers.v2 import SimulateManager, TransfersManager
 from fintoc.version import __version__
 
 
@@ -24,24 +27,39 @@ class Fintoc:
 
     """Encapsulates the core object's behaviour and methods."""
 
-    def __init__(self, api_key, api_version=None):
+    def __init__(self, api_key, api_version=None, jws_private_key=None):
         self._client = Client(
-            base_url=f"{API_BASE_URL}/{API_VERSION}",
+            base_url=f"{API_BASE_URL}",
             api_key=api_key,
             api_version=api_version,
             user_agent=f"fintoc-python/{__version__}",
+            jws_private_key=jws_private_key,
         )
-        self.charges = ChargesManager("/charges", self._client)
-        self.links = LinksManager("/links", self._client)
-        self.payment_intents = PaymentIntentsManager("/payment_intents", self._client)
-        self.subscriptions = SubscriptionsManager("/subscriptions", self._client)
+        self.charges = ChargesManager("/v1/charges", self._client)
+        self.links = LinksManager("/v1/links", self._client)
+        self.payment_intents = PaymentIntentsManager(
+            "/v1/payment_intents", self._client
+        )
+        self.subscriptions = SubscriptionsManager("/v1/subscriptions", self._client)
         self.subscription_intents = SubscriptionIntentsManager(
-            "/subscription_intents", self._client
+            "/v1/subscription_intents", self._client
         )
         self.webhook_endpoints = WebhookEndpointsManager(
-            "/webhook_endpoints", self._client
+            "/v1/webhook_endpoints", self._client
         )
-        self.accounts = AccountsManager("/accounts", self._client)
-        self.refresh_intents = RefreshIntentsManager("/refresh_intents", self._client)
-        self.tax_returns = TaxReturnsManager("/tax_returns", self._client)
-        self.invoices = InvoicesManager("/invoices", self._client)
+        self.accounts = AccountsManager("/v1/accounts", self._client)
+        self.refresh_intents = RefreshIntentsManager(
+            "/v1/refresh_intents", self._client
+        )
+        self.tax_returns = TaxReturnsManager("/v1/tax_returns", self._client)
+        self.invoices = InvoicesManager("/v1/invoices", self._client)
+
+        self.v2 = _FintocV2(self._client)
+
+
+class _FintocV2:
+    def __init__(self, client):
+        self.transfers = TransfersManager("/v2/transfers", client)
+        self.accounts = AccountsManagerV2("/v2/accounts", client)
+        self.account_numbers = AccountNumbersManager("/v2/account_numbers", client)
+        self.simulate = SimulateManager("/v2/simulate", client)

--- a/fintoc/jws.py
+++ b/fintoc/jws.py
@@ -1,0 +1,100 @@
+"""Module to handle JWS signature generation for Fintoc API requests."""
+
+import base64
+import json
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import Union
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+
+
+class JWSSignature:
+    """Class to handle JWS signature generation for Fintoc API requests."""
+
+    def __init__(self, private_key: Union[str, bytes, Path]):
+        """
+        Initialize the JWSSignature with a private key.
+
+        Args:
+            private_key: The RSA private key in one of these formats:
+                - String containing PEM-formatted key
+                - Bytes containing PEM-formatted key
+                - Path object or string path to a PEM key file
+
+        Example:
+            >>> # From a string
+            >>> with open('private_key.pem', 'r') as f:
+            ...     key_str = f.read()
+            >>> jws = JWSSignature(key_str)
+            >>>
+            >>> # From a file path
+            >>> jws = JWSSignature('private_key.pem')
+            >>>
+            >>> # From environment variable
+            >>> jws = JWSSignature(os.environ.get('PRIVATE_KEY'))
+        """
+        if isinstance(private_key, (str, Path)) and os.path.isfile(str(private_key)):
+            with open(private_key, "rb") as key_file:
+                private_key_bytes = key_file.read()
+        elif isinstance(private_key, str):
+            private_key_bytes = private_key.encode()
+        elif isinstance(private_key, bytes):
+            private_key_bytes = private_key
+        else:
+            raise ValueError(
+                "private_key must be a PEM string, bytes, or a path to a key file"
+            )
+
+        self.private_key = serialization.load_pem_private_key(
+            private_key_bytes, password=None
+        )
+
+    def generate_header(self, raw_body: Union[str, dict]) -> str:
+        """
+        Generate a JWS signature header for Fintoc API requests.
+
+        Args:
+            raw_body: The request body as a string or dict. If dict, it will be
+            converted to JSON.
+
+        Returns:
+            str: The JWS signature header to be used in the 'Fintoc-JWS-Signature'
+            header.
+
+        Example:
+            >>> jws = JWSSignature(private_key)
+            >>> body = {"amount": 1000, "currency": "CLP"}
+            >>> jws_header = jws.generate_header(body)
+            >>> # Use in request headers:
+            >>> headers = {
+            ...     'Fintoc-JWS-Signature': jws_header,
+            ...     'Authorization': 'Bearer sk_test...'
+            ... }
+        """
+        if isinstance(raw_body, dict):
+            raw_body = json.dumps(raw_body)
+
+        headers = {
+            "alg": "RS256",
+            "nonce": secrets.token_hex(16),
+            "ts": int(time.time()),
+            "crit": ["ts", "nonce"],
+        }
+
+        protected_base64 = (
+            base64.urlsafe_b64encode(json.dumps(headers).encode()).rstrip(b"=").decode()
+        )
+        payload_base64 = (
+            base64.urlsafe_b64encode(raw_body.encode()).rstrip(b"=").decode()
+        )
+        signing_input = f"{protected_base64}.{payload_base64}"
+        signature_raw = self.private_key.sign(
+            signing_input.encode(), padding.PKCS1v15(), hashes.SHA256()
+        )
+        signature_base64 = base64.urlsafe_b64encode(signature_raw).rstrip(b"=").decode()
+
+        return f"{protected_base64}.{signature_base64}"

--- a/fintoc/managers/accounts_manager.py
+++ b/fintoc/managers/accounts_manager.py
@@ -21,7 +21,7 @@ class AccountsManager(ManagerMixin):
         """Proxies the movements manager."""
         if self.__movements_manager is None:
             self.__movements_manager = MovementsManager(
-                "/accounts/{account_id}/movements",
+                "/v1/accounts/{account_id}/movements",
                 self._client,
             )
         return self.__movements_manager

--- a/fintoc/managers/v2/__init__.py
+++ b/fintoc/managers/v2/__init__.py
@@ -1,0 +1,6 @@
+"""Init file for the v2 managers module of the SDK."""
+
+from .account_numbers_manager import AccountNumbersManager
+from .accounts_manager import AccountsManager
+from .simulate_manager import SimulateManager
+from .transfers_manager import TransfersManager

--- a/fintoc/managers/v2/account_numbers_manager.py
+++ b/fintoc/managers/v2/account_numbers_manager.py
@@ -1,0 +1,10 @@
+"""Module to hold the account numbers manager."""
+
+from fintoc.mixins import ManagerMixin
+
+
+class AccountNumbersManager(ManagerMixin):
+    """Represents an account numbers manager."""
+
+    resource = "account_number"
+    methods = ["all", "get", "update", "create", "delete"]

--- a/fintoc/managers/v2/accounts_manager.py
+++ b/fintoc/managers/v2/accounts_manager.py
@@ -1,0 +1,10 @@
+"""Module to hold the accounts manager."""
+
+from fintoc.mixins import ManagerMixin
+
+
+class AccountsManager(ManagerMixin):
+    """Represents an accounts manager."""
+
+    resource = "account"
+    methods = ["all", "get", "create"]

--- a/fintoc/managers/v2/simulate_manager.py
+++ b/fintoc/managers/v2/simulate_manager.py
@@ -1,0 +1,14 @@
+"""Module to hold the simulate manager."""
+
+from fintoc.mixins import ManagerMixin
+
+
+class SimulateManager(ManagerMixin):
+    """Represents a simulate manager for testing purposes."""
+
+    resource = "transfer"
+    methods = ["receive_transfer"]
+
+    def _receive_transfer(self, **kwargs):
+        path = f"{self._build_path(**kwargs)}/receive_transfer"
+        return self._create(path_=path, **kwargs)

--- a/fintoc/managers/v2/transfers_manager.py
+++ b/fintoc/managers/v2/transfers_manager.py
@@ -1,0 +1,10 @@
+"""Module to hold the transfers manager."""
+
+from fintoc.mixins import ManagerMixin
+
+
+class TransfersManager(ManagerMixin):
+    """Represents a transfers manager."""
+
+    resource = "transfer"
+    methods = ["all", "get", "create"]

--- a/fintoc/mixins/manager_mixin.py
+++ b/fintoc/mixins/manager_mixin.py
@@ -86,15 +86,16 @@ class ManagerMixin(metaclass=ABCMeta):  # pylint: disable=no-self-use
         return self.post_get_handler(object_, identifier, **kwargs)
 
     @can_raise_fintoc_error
-    def _create(self, **kwargs):
+    def _create(self, path_=None, **kwargs):
         """
         Create an instance of the resource being handled by the manager.
         Data is passed using :kwargs:, as specified by the API.
         """
         klass = get_resource_class(self.__class__.resource)
+        path = path_ if path_ else self._build_path(**kwargs)
         object_ = resource_create(
             client=self._client,
-            path=self._build_path(**kwargs),
+            path=path,
             klass=klass,
             handlers=self._handlers,
             methods=self.__class__.methods,

--- a/fintoc/paginator.py
+++ b/fintoc/paginator.py
@@ -43,7 +43,7 @@ def parse_link_headers(link_header):
     Receive the 'link' header and return a dictionary with
     every key: value instance present on the header.
     """
-    if link_header is None:
+    if not link_header:
         return None
     return reduce(parse_link, link_header.split(","), {})
 

--- a/fintoc/resources/__init__.py
+++ b/fintoc/resources/__init__.py
@@ -21,4 +21,7 @@ from .tax_return import TaxReturn
 from .taxpayer import Taxpayer
 from .tobacco_taxes import TobaccoTaxes
 from .transfer_account import TransferAccount
+from .v2.account import Account as AccountV2
+from .v2.account_number import AccountNumber
+from .v2.transfer import Transfer
 from .webhook_endpoint import WebhookEndpoint

--- a/fintoc/resources/account.py
+++ b/fintoc/resources/account.py
@@ -17,8 +17,7 @@ class Account(ResourceMixin):
         """Proxies the movements manager."""
         if self.__movements_manager is None:
             self.__movements_manager = MovementsManager(
-                f"/accounts/{self.id}/movements",
-                self._client,
+                f"/v1/accounts/{self.id}/movements", self._client
             )
         return self.__movements_manager
 

--- a/fintoc/resources/link.py
+++ b/fintoc/resources/link.py
@@ -28,7 +28,7 @@ class Link(ResourceMixin):
     def accounts(self):
         """Proxies the accounts manager."""
         if self.__accounts_manager is None:
-            self.__accounts_manager = AccountsManager("/accounts", self._client)
+            self.__accounts_manager = AccountsManager("/v1/accounts", self._client)
         return self.__accounts_manager
 
     @accounts.setter
@@ -42,7 +42,7 @@ class Link(ResourceMixin):
         """Proxies the subscriptions manager."""
         if self.__subscriptions_manager is None:
             self.__subscriptions_manager = SubscriptionsManager(
-                "/subscriptions", self._client
+                "/v1/subscriptions", self._client
             )
         return self.__subscriptions_manager
 
@@ -54,7 +54,9 @@ class Link(ResourceMixin):
     def tax_returns(self):
         """Proxies the tax_returns manager."""
         if self.__tax_returns_manager is None:
-            self.__tax_returns_manager = TaxReturnsManager("/tax_returns", self._client)
+            self.__tax_returns_manager = TaxReturnsManager(
+                "/v1/tax_returns", self._client
+            )
         return self.__tax_returns_manager
 
     @tax_returns.setter
@@ -65,7 +67,7 @@ class Link(ResourceMixin):
     def invoices(self):
         """Proxies the invoices manager."""
         if self.__invoices_manager is None:
-            self.__invoices_manager = InvoicesManager("/invoices", self._client)
+            self.__invoices_manager = InvoicesManager("/v1/invoices", self._client)
         return self.__invoices_manager
 
     @invoices.setter
@@ -77,7 +79,7 @@ class Link(ResourceMixin):
         """Proxies the refresh_intents manager."""
         if self.__refresh_intents_manager is None:
             self.__refresh_intents_manager = RefreshIntentsManager(
-                "/refresh_intents", self._client
+                "/v1/refresh_intents", self._client
             )
         return self.__refresh_intents_manager
 

--- a/fintoc/resources/v2/__init__.py
+++ b/fintoc/resources/v2/__init__.py
@@ -1,0 +1,5 @@
+"""Init file for the v2 resources module of the SDK."""
+
+from .account import Account
+from .account_number import AccountNumber
+from .transfer import Transfer

--- a/fintoc/resources/v2/account.py
+++ b/fintoc/resources/v2/account.py
@@ -1,0 +1,7 @@
+"""Module to hold the Account resource."""
+
+from fintoc.mixins import ResourceMixin
+
+
+class Account(ResourceMixin):
+    """Represents a Fintoc Account."""

--- a/fintoc/resources/v2/account_number.py
+++ b/fintoc/resources/v2/account_number.py
@@ -1,0 +1,7 @@
+"""Module to hold the AccountNumber resource."""
+
+from fintoc.mixins import ResourceMixin
+
+
+class AccountNumber(ResourceMixin):
+    """Represents a Fintoc AccountNumber."""

--- a/fintoc/resources/v2/transfer.py
+++ b/fintoc/resources/v2/transfer.py
@@ -1,0 +1,7 @@
+"""Module to hold the Transfer resource."""
+
+from fintoc.mixins import ResourceMixin
+
+
+class Transfer(ResourceMixin):
+    """Represents a Fintoc Transfer."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -130,6 +130,84 @@ files = [
 ]
 
 [[package]]
+name = "cffi"
+version = "1.15.1"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
+]
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
@@ -220,6 +298,56 @@ files = [
 
 [package.extras]
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
+
+[[package]]
+name = "cryptography"
+version = "43.0.3"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "cryptography-43.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf7a1932ac4176486eab36a19ed4c0492da5d97123f1406cf15e41b05e787d2e"},
+    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63efa177ff54aec6e1c0aefaa1a241232dcd37413835a9b674b6e3f0ae2bfd3e"},
+    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e1ce50266f4f70bf41a2c6dc4358afadae90e2a1e5342d3c08883df1675374f"},
+    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:443c4a81bb10daed9a8f334365fe52542771f25aedaf889fd323a853ce7377d6"},
+    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:74f57f24754fe349223792466a709f8e0c093205ff0dca557af51072ff47ab18"},
+    {file = "cryptography-43.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9762ea51a8fc2a88b70cf2995e5675b38d93bf36bd67d91721c309df184f49bd"},
+    {file = "cryptography-43.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:81ef806b1fef6b06dcebad789f988d3b37ccaee225695cf3e07648eee0fc6b73"},
+    {file = "cryptography-43.0.3-cp37-abi3-win32.whl", hash = "sha256:cbeb489927bd7af4aa98d4b261af9a5bc025bd87f0e3547e11584be9e9427be2"},
+    {file = "cryptography-43.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:f46304d6f0c6ab8e52770addfa2fc41e6629495548862279641972b6215451cd"},
+    {file = "cryptography-43.0.3-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:8ac43ae87929a5982f5948ceda07001ee5e83227fd69cf55b109144938d96984"},
+    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:846da004a5804145a5f441b8530b4bf35afbf7da70f82409f151695b127213d5"},
+    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4"},
+    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7"},
+    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c2e6fc39c4ab499049df3bdf567f768a723a5e8464816e8f009f121a5a9f4405"},
+    {file = "cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e1be4655c7ef6e1bbe6b5d0403526601323420bcf414598955968c9ef3eb7d16"},
+    {file = "cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:df6b6c6d742395dd77a23ea3728ab62f98379eff8fb61be2744d4679ab678f73"},
+    {file = "cryptography-43.0.3-cp39-abi3-win32.whl", hash = "sha256:d56e96520b1020449bbace2b78b603442e7e378a9b3bd68de65c782db1507995"},
+    {file = "cryptography-43.0.3-cp39-abi3-win_amd64.whl", hash = "sha256:0c580952eef9bf68c4747774cde7ec1d85a6e61de97281f2dba83c7d2c806362"},
+    {file = "cryptography-43.0.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:d03b5621a135bffecad2c73e9f4deb1a0f977b9a8ffe6f8e002bf6c9d07b918c"},
+    {file = "cryptography-43.0.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a2a431ee15799d6db9fe80c82b055bae5a752bef645bba795e8e52687c69efe3"},
+    {file = "cryptography-43.0.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:281c945d0e28c92ca5e5930664c1cefd85efe80e5c0d2bc58dd63383fda29f83"},
+    {file = "cryptography-43.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:f18c716be16bc1fea8e95def49edf46b82fccaa88587a45f8dc0ff6ab5d8e0a7"},
+    {file = "cryptography-43.0.3-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4a02ded6cd4f0a5562a8887df8b3bd14e822a90f97ac5e544c162899bc467664"},
+    {file = "cryptography-43.0.3-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:53a583b6637ab4c4e3591a15bc9db855b8d9dee9a669b550f311480acab6eb08"},
+    {file = "cryptography-43.0.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:1ec0bcf7e17c0c5669d881b1cd38c4972fade441b27bda1051665faaa89bdcaa"},
+    {file = "cryptography-43.0.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2ce6fae5bdad59577b44e4dfed356944fbf1d925269114c28be377692643b4ff"},
+    {file = "cryptography-43.0.3.tar.gz", hash = "sha256:315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
+docstest = ["pyenchant (>=1.6.11)", "readme-renderer", "sphinxcontrib-spelling (>=4.0.1)"]
+nox = ["nox"]
+pep8test = ["check-sdist", "click", "mypy", "ruff"]
+sdist = ["build"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi", "cryptography-vectors (==43.0.3)", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dill"
@@ -531,6 +659,19 @@ groups = ["dev"]
 files = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+]
+
+[[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 
 [[package]]
@@ -882,4 +1023,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.7"
-content-hash = "6515b6b7ab4b284670701c5cf9ddd0e3a3eed51cd4a54fcd872df50a006b2914"
+content-hash = "ccf1b3ca7aaf4ac0226376a8d18e0212eb18c0b5062496aa31a7b0953946108a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ exclude = [
 [tool.poetry.dependencies]
 python = "^3.7"
 httpx = ">=0.16, < 1.0"
+cryptography = "<44.0.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.10.0"

--- a/tests/mixins/test_manager_mixin.py
+++ b/tests/mixins/test_manager_mixin.py
@@ -133,6 +133,10 @@ class TestManagerMixinMethods:
         object_ = self.manager.create()
         assert isinstance(object_, ResourceMixin)
         assert object_.method == "post"
+        assert object_.url == self.path.lstrip("/")
+
+        object_ = self.manager.create(path_="/resources/custom_path")
+        assert object_.url == "resources/custom_path"
 
     def test_update_method(self):
         object_ = self.manager.update("my_id")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -483,6 +483,153 @@ class TestFintocIntegration:
 
         assert result == webhook_endpoint_id
 
+    def test_v2_accounts_all(self):
+        """Test getting all accounts using v2 API."""
+        accounts = list(self.fintoc.v2.accounts.all())
+
+        assert len(accounts) > 0
+        for account in accounts:
+            assert account.method == "get"
+            assert account.url == "v2/accounts"
+
+    def test_v2_account_get(self):
+        """Test getting a specific account using v2 API."""
+        account_id = "test_account_id"
+
+        account = self.fintoc.v2.accounts.get(account_id)
+
+        assert account.method == "get"
+        assert account.url == f"v2/accounts/{account_id}"
+
+    def test_v2_account_create(self):
+        """Test creating an account using v2 API."""
+        account_data = {"description": "New test account"}
+
+        account = self.fintoc.v2.accounts.create(**account_data)
+
+        assert account.method == "post"
+        assert account.url == "v2/accounts"
+        assert account.json.description == account_data["description"]
+
+    def test_v2_account_numbers_all(self):
+        """Test getting all account numbers using v2 API."""
+        account_id = "test_account_id"
+        account_numbers = list(
+            self.fintoc.v2.account_numbers.all(account_id=account_id)
+        )
+
+        assert len(account_numbers) > 0
+        for account_number in account_numbers:
+            assert account_number.method == "get"
+            assert account_number.url == "v2/account_numbers"
+            assert account_number.params.account_id == account_id
+
+    def test_v2_account_number_get(self):
+        """Test getting a specific account number using v2 API."""
+        account_number_id = "test_account_number_id"
+
+        account_number = self.fintoc.v2.account_numbers.get(account_number_id)
+
+        assert account_number.method == "get"
+        assert account_number.url == f"v2/account_numbers/{account_number_id}"
+
+    def test_v2_account_number_create(self):
+        """Test creating an account number using v2 API."""
+        account_id = "test_account_id"
+
+        description = "Test account number"
+        metadata = {"test_key": "test_value"}
+
+        account_number = self.fintoc.v2.account_numbers.create(
+            account_id=account_id, description=description, metadata=metadata
+        )
+
+        assert account_number.method == "post"
+        assert account_number.url == "v2/account_numbers"
+        assert account_number.json.description == description
+        assert account_number.json.metadata.test_key == metadata["test_key"]
+        assert account_number.json.account_id == account_id
+
+    def test_v2_account_number_update(self):
+        """Test updating an account number using v2 API."""
+        account_number_id = "test_account_number_id"
+        metadata = {"test_key": "test_value"}
+
+        account_number = self.fintoc.v2.account_numbers.update(
+            account_number_id, metadata=metadata
+        )
+
+        assert account_number.method == "patch"
+        assert account_number.url == f"v2/account_numbers/{account_number_id}"
+        assert account_number.json.metadata.test_key == metadata["test_key"]
+
+    def test_v2_account_number_delete(self):
+        """Test deleting an account number using v2 API."""
+        account_number_id = "test_account_number_id"
+
+        result = self.fintoc.v2.account_numbers.delete(account_number_id)
+
+        assert result == account_number_id
+
+    def test_v2_transfers_all(self):
+        """Test getting all transfers using v2 API."""
+        account_id = "test_account_id"
+        transfers = list(self.fintoc.v2.transfers.all(account_id=account_id))
+
+        assert len(transfers) > 0
+        for transfer in transfers:
+            assert transfer.method == "get"
+            assert transfer.url == "v2/transfers"
+            assert transfer.params.account_id == account_id
+
+    def test_v2_transfer_get(self):
+        """Test getting a specific transfer using v2 API."""
+        transfer_id = "test_transfer_id"
+
+        transfer = self.fintoc.v2.transfers.get(transfer_id)
+
+        assert transfer.method == "get"
+        assert transfer.url == f"v2/transfers/{transfer_id}"
+
+    def test_v2_transfer_create(self):
+        """Test creating a transfer using v2 API."""
+        account_id = "test_account_id"
+        amount = 10000
+        currency = "MXN"
+        description = "Test transfer"
+        metadata = {"test_key": "test_value"}
+
+        transfer = self.fintoc.v2.transfers.create(
+            account_id=account_id,
+            amount=amount,
+            currency=currency,
+            description=description,
+            metadata=metadata,
+        )
+
+        assert transfer.method == "post"
+        assert transfer.url == "v2/transfers"
+        assert transfer.json.amount == amount
+        assert transfer.json.currency == currency
+        assert transfer.json.description == description
+        assert transfer.json.metadata.test_key == metadata["test_key"]
+
+    def test_v2_simulate_receive_transfer(self):
+        """Test simulating receiving a transfer using v2 API."""
+        account_number_id = "test_account_number_id"
+        amount = 10000
+        currency = "MXN"
+
+        transfer = self.fintoc.v2.simulate.receive_transfer(
+            account_number_id=account_number_id, amount=amount, currency=currency
+        )
+
+        assert transfer.method == "post"
+        assert transfer.url == "v2/simulate/receive_transfer"
+        assert transfer.json.amount == amount
+        assert transfer.json.currency == currency
+        assert transfer.json.account_number_id == account_number_id
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -1,0 +1,162 @@
+"""Tests for the JWS signature generation."""
+
+import base64
+import json
+import time
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from fintoc.jws import JWSSignature
+
+
+@pytest.fixture(name="private_key")
+def fixture_private_key():
+    """Generate a test RSA private key."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem
+
+
+@pytest.fixture(name="private_key_file")
+def fixture_private_key_file(private_key, tmp_path):
+    """Create a temporary file with the test private key."""
+    key_path = tmp_path / "private_key.pem"
+    key_path.write_bytes(private_key)
+    return key_path
+
+
+class TestJWSSignature:
+    """Test cases for JWSSignature class."""
+
+    def test_init_with_string(self, private_key):
+        """Test initializing with PEM string."""
+        jws = JWSSignature(private_key.decode())
+        assert jws.private_key is not None
+
+    def test_init_with_bytes(self, private_key):
+        """Test initializing with PEM bytes."""
+        jws = JWSSignature(private_key)
+        assert jws.private_key is not None
+
+    def test_init_with_path_string(self, private_key_file):
+        """Test initializing with path as string."""
+        jws = JWSSignature(str(private_key_file))
+        assert jws.private_key is not None
+
+    def test_init_with_path_object(self, private_key_file):
+        """Test initializing with Path object."""
+        jws = JWSSignature(private_key_file)
+        assert jws.private_key is not None
+
+    def test_init_with_invalid_type(self):
+        """Test initializing with invalid type raises ValueError."""
+        with pytest.raises(ValueError):
+            JWSSignature(123)
+
+    def test_init_with_invalid_path(self):
+        """Test initializing with non-existent file path."""
+        with pytest.raises(ValueError):
+            JWSSignature("nonexistent.pem")
+
+    def test_init_with_invalid_key_format(self):
+        """Test initializing with invalid key format."""
+        with pytest.raises(ValueError):
+            JWSSignature("not a valid key")
+
+    def test_generate_header_with_dict(self, private_key):
+        """Test generating header with dict payload."""
+        jws = JWSSignature(private_key)
+        payload = {"amount": 1000, "currency": "CLP"}
+        header = jws.generate_header(payload)
+
+        parts = header.split(".")
+        assert len(parts) == 2
+
+        protected = json.loads(
+            base64.urlsafe_b64decode(parts[0] + "=" * (4 - len(parts[0]) % 4)).decode()
+        )
+
+        assert protected["alg"] == "RS256"
+        assert "nonce" in protected
+        assert "ts" in protected
+        assert protected["crit"] == ["ts", "nonce"]
+
+    def test_generate_header_with_string(self, private_key):
+        """Test generating header with string payload."""
+        jws = JWSSignature(private_key)
+        payload = json.dumps({"amount": 1000, "currency": "CLP"})
+        header = jws.generate_header(payload)
+
+        parts = header.split(".")
+        assert len(parts) == 2
+
+        protected = json.loads(
+            base64.urlsafe_b64decode(parts[0] + "=" * (4 - len(parts[0]) % 4)).decode()
+        )
+
+        assert protected["alg"] == "RS256"
+        assert "nonce" in protected
+        assert "ts" in protected
+        assert protected["crit"] == ["ts", "nonce"]
+
+    def test_header_verification(self, private_key):
+        """Test that generated headers can be verified."""
+        jws = JWSSignature(private_key)
+        payload = {"amount": 1000, "currency": "CLP"}
+        header = jws.generate_header(payload)
+
+        protected_b64, signature_b64 = header.split(".")
+        payload_b64 = (
+            base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+        )
+        signing_input = f"{protected_b64}.{payload_b64}"
+        signature = base64.urlsafe_b64decode(
+            signature_b64 + "=" * (4 - len(signature_b64) % 4)
+        )
+
+        public_key = serialization.load_pem_private_key(
+            private_key, password=None
+        ).public_key()
+
+        # This should not raise an exception
+        public_key.verify(
+            signature, signing_input.encode(), padding.PKCS1v15(), hashes.SHA256()
+        )
+
+    def test_timestamp_is_current(self, private_key):
+        """Test that generated timestamp is current."""
+        jws = JWSSignature(private_key)
+        payload = {"test": "data"}
+        header = jws.generate_header(payload)
+
+        protected_b64 = header.split(".")[0]
+        protected = json.loads(
+            base64.urlsafe_b64decode(
+                protected_b64 + "=" * (4 - len(protected_b64) % 4)
+            ).decode()
+        )
+
+        assert abs(protected["ts"] - int(time.time())) < 10
+
+    def test_nonce_is_random(self, private_key):
+        """Test that nonce is random for each call."""
+        jws = JWSSignature(private_key)
+        payload = {"test": "data"}
+
+        header1 = jws.generate_header(payload)
+        header2 = jws.generate_header(payload)
+
+        protected1 = json.loads(
+            base64.urlsafe_b64decode(header1.split(".")[0] + "====").decode()
+        )
+        protected2 = json.loads(
+            base64.urlsafe_b64decode(header2.split(".")[0] + "====").decode()
+        )
+
+        assert protected1["nonce"] != protected2["nonce"]


### PR DESCRIPTION
## Description

This PR adds support for v2/transfers product. It includes generating the JWS and all the endpoints for transfers.

```python
import os

from fintoc import Fintoc

# Provide a path to your PEM file
client = Fintoc("your_api_key", jws_private_key="private_key.pem")

# Or pass the PEM key directly as a string
client = Fintoc("your_api_key", jws_private_key=os.environ.get('JWS_PRIVATE_KEY'))

transfer = client.v2.transfers.create(
        amount=49523,
        currency="mxn",
        account_id="acc_123545",
        counterparty={
                "account_number": "014180655091438298"
            },
        metadata={
                "factura": '14814'
            }
        )

transfer = client.v2.simulate.receive_transfer(
        amount=9912400,
        currency="mxn",
        account_number_id="acno_2vF18OHZdXXxPJTLJ5qghpo1pdU",
        )
```


## Requirements

None.

## Additional changes

None.
