### PR TITLE
Feat/add idempotency key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
     - [V2 Endpoints](#v2-endpoints)
     - [Nested actions or resources](#nested-actions-or-resources)
   - [Webhook Signature Validation](#webhook-signature-validation)
+  - [Idempotency Keys](#idempotency-keys)
   - [Generate the JWS Signature](#gnerate-the-jws-signature)
   - [Serialization](#serialization)
 - [Acknowledgements](#acknowledgements)
@@ -154,17 +155,12 @@ To call v2 API endpoints, like the [Transfers API](https://docs.fintoc.com/refer
 
 ```python
 transfer = client.v2.transfers.create(
-        amount=49523,
-        currency="mxn",
-        account_id="acc_123545",
-        counterparty={
-                "account_number": "014180655091438298"
-            },
-        metadata={
-                "factura": '14814'
-            }
-        )
-
+    amount=49523,
+    currency="mxn",
+    account_id="acc_123545",
+    counterparty={"account_number": "014180655091438298"},
+    metadata={"factura": "14814"},
+)
 ```
 
 #### Nested actions or resources
@@ -173,10 +169,10 @@ To call nested actions just call the method as it appears in the API. For exampl
 
 ```python
 transfer = client.v2.simulate.receive_transfer(
-        amount=9912400,
-        currency="mxn",
-        account_number_id="acno_2vF18OHZdXXxPJTLJ5qghpo1pdU",
-        )
+    amount=9912400,
+    currency="mxn",
+    account_number_id="acno_2vF18OHZdXXxPJTLJ5qghpo1pdU",
+)
 ```
 
 ### Webhook Signature Validation
@@ -200,6 +196,21 @@ The `verify_header` method takes the following parameters:
 If the signature is invalid or the timestamp is outside the tolerance window, a `WebhookSignatureError` will be raised with a descriptive message.
 
 For a complete example of handling webhooks, see [examples/webhook.py](examples/webhook.py).
+
+### Idempotency Keys
+
+You can provide an [Idempotency Key](https://docs.fintoc.com/reference/idempotent-requests) using the `idempotency_key` argument. For example:
+
+```python
+transfer = client.v2.transfers.create(
+    idempotency_key="12345678910"
+    amount=49523,
+    currency="mxn",
+    account_id="acc_123545",
+    counterparty={"account_number": "014180655091438298"},
+    metadata={"factura": "14814"},
+)
+```
 
 ### Generate the JWS Signature
 

--- a/fintoc/mixins/manager_mixin.py
+++ b/fintoc/mixins/manager_mixin.py
@@ -86,7 +86,7 @@ class ManagerMixin(metaclass=ABCMeta):  # pylint: disable=no-self-use
         return self.post_get_handler(object_, identifier, **kwargs)
 
     @can_raise_fintoc_error
-    def _create(self, path_=None, **kwargs):
+    def _create(self, idempotency_key=None, path_=None, **kwargs):
         """
         Create an instance of the resource being handled by the manager.
         Data is passed using :kwargs:, as specified by the API.
@@ -100,6 +100,7 @@ class ManagerMixin(metaclass=ABCMeta):  # pylint: disable=no-self-use
             handlers=self._handlers,
             methods=self.__class__.methods,
             params=kwargs,
+            idempotency_key=idempotency_key,
         )
         return self.post_create_handler(object_, **kwargs)
 

--- a/fintoc/resource_handlers.py
+++ b/fintoc/resource_handlers.py
@@ -42,9 +42,13 @@ def resource_get(client, path, id_, klass, handlers, methods, params):
     )
 
 
-def resource_create(client, path, klass, handlers, methods, params):
+def resource_create(
+    client, path, klass, handlers, methods, params, idempotency_key=None
+):
     """Create a new instance of a resource."""
-    data = client.request(path, method="post", json=params)
+    data = client.request(
+        path, method="post", json=params, idempotency_key=idempotency_key
+    )
     return objetize(
         klass,
         client,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def patch_http_error(monkeypatch):
 @pytest.fixture
 def patch_http_client(monkeypatch):
     class MockResponse:
-        def __init__(self, method, base_url, url, params, json):
+        def __init__(self, method, base_url, url, params, json, headers):
             self._base_url = base_url
             self._params = params
             page = None
@@ -44,6 +44,7 @@ def patch_http_client(monkeypatch):
             self._method = method
             self._url = url
             self._json = json
+            self._headers = headers
 
             # Extract the ID from the URL if it's a specific resource request
             self._id = None
@@ -52,11 +53,14 @@ def patch_http_client(monkeypatch):
 
         @property
         def headers(self):
+            resp_headers = dict(self._headers)
             if self._page is not None and self._page < 10:
                 params = "&".join([*self.formatted_params, f"page={self._page + 1}"])
                 url = self._url.lstrip("/")
-                return {"link": (f"<{self._base_url}/{url}?{params}>; " 'rel="next"')}
-            return {}
+                resp_headers["link"] = (
+                    f"<{self._base_url}/{url}?{params}>; " 'rel="next"'
+                )
+            return resp_headers
 
         @property
         def formatted_params(self):
@@ -77,6 +81,7 @@ def patch_http_client(monkeypatch):
                         "params": self._params,
                         "json": self._json,
                         "page": self._page,
+                        "headers": self.headers,
                     }
                     for _ in range(10)
                 ]
@@ -87,16 +92,17 @@ def patch_http_client(monkeypatch):
                 "url": self._url,
                 "params": self._params,
                 "json": self._json,
+                "headers": self.headers,
             }
 
     class MockClient(httpx.Client):
-        def request(self, method, url, params=None, json=None, **kwargs):
+        def request(self, method, url, params=None, json=None, headers=None, **kwargs):
             query = url.split("?")[-1].split("&") if "?" in url else []
             inner_params = {y[0]: y[1] for y in (x.split("=") for x in query)}
             complete_params = {**inner_params, **({} if params is None else params)}
             usable_url = url.split("//")[-1].split("/", 1)[-1].split("?")[0]
             return MockResponse(
-                method, self.base_url, usable_url, complete_params, json
+                method, self.base_url, usable_url, complete_params, json, headers
             )
 
     monkeypatch.setattr(httpx, "Client", MockClient)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -116,3 +116,19 @@ class TestClientRequestFunctionality:
         data = self.client.request("/movements/3", method="delete")
         assert isinstance(data, dict)
         assert len(data.keys()) == 0
+
+    def test_post_request(self):
+        data = self.client.request("/v2/transfers", method="post")
+        assert isinstance(data, dict)
+
+        idempotency_key = data["headers"]["Idempotency-Key"]
+        assert idempotency_key is not None and idempotency_key != ""
+
+    def test_post_request_with_custom_idempotency_key(self):
+        data = self.client.request(
+            "/v2/transfers", method="post", idempotency_key="1234"
+        )
+        assert isinstance(data, dict)
+
+        idempotency_key = data["headers"]["Idempotency-Key"]
+        assert idempotency_key == "1234"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -614,6 +614,21 @@ class TestFintocIntegration:
         assert transfer.json.description == description
         assert transfer.json.metadata.test_key == metadata["test_key"]
 
+        idempotency_key_header = transfer.serialize()["headers"]["Idempotency-Key"]
+        assert idempotency_key_header is not None and idempotency_key_header != ""
+
+        idempotency_key = "123456"
+        transfer = self.fintoc.v2.transfers.create(
+            account_id=account_id,
+            amount=amount,
+            currency=currency,
+            description=description,
+            metadata=metadata,
+            idempotency_key=idempotency_key,
+        )
+        idempotency_key_header = transfer.serialize()["headers"]["Idempotency-Key"]
+        assert idempotency_key_header == "123456"
+
     def test_v2_simulate_receive_transfer(self):
         """Test simulating receiving a transfer using v2 API."""
         account_number_id = "test_account_number_id"


### PR DESCRIPTION
## Description

Add the option to add idempotency keys to `POST` requests:

```python
transfer = client.v2.transfers.create(
    idempotency_key="12345678910"
    amount=49523,
    currency="mxn",
    account_id="acc_123545",
    counterparty={"account_number": "014180655091438298"},
    metadata={"factura": "14814"},
)
```

When no idempotency key is passed by the user, the SDK automatically provides one. We will use this feature to do automatic retries in a future PR 👀 

## Requirements

None.

## Additional changes

None.
