### PR TITLE
feat: replace all() with list(), maintaining backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - [Usage](#usage)
   - [Quickstart](#quickstart)
   - [Calling endpoints](#calling-endpoints)
-    - [all](#all)
+    - [list](#list)
     - [get](#get)
     - [create](#create)
     - [update](#update)
@@ -66,7 +66,7 @@ from fintoc import Fintoc
 client = Fintoc("your_api_key")
 
 # list all succeeded payment intents since the beginning of 2025
-payment_intents = client.payment_intents.all(since="2025-01-01", status="succeeded")
+payment_intents = client.payment_intents.list(since="2025-01-01", status="succeeded")
 for pi in payment_intents:
     print(pi.created_at, pi.amount, pi.customer_email)
 
@@ -81,24 +81,24 @@ The SDK provides direct access to Fintoc API resources following the API structu
 
 Notice that **not every resource has all of the methods**, as they correspond to the API capabilities.
 
-#### `all`
+#### `list`
 
-You can use the `all` method to list all the instances of the resource:
+You can use the `list` method to list all the instances of the resource:
 
 ```python
-webhook_endpoints = client.webhook_endpoints.all()
+webhook_endpoints = client.webhook_endpoints.list()
 ```
 
-The `all` method returns **a generator** with all the instances of the resource. This method can also receive the arguments that the API receives for that specific resource. For example, the `PaymentIntent` resource can be filtered using `since` and `until`, so if you wanted to get a range of `payment intents`, all you need to do is to pass the parameters to the method:
+The `list` method returns **a generator** with all the instances of the resource. This method can also receive the arguments that the API receives for that specific resource. For example, the `PaymentIntent` resource can be filtered using `since` and `until`, so if you wanted to get a range of `payment intents`, all you need to do is to pass the parameters to the method:
 
 ```python
-payment_intents = client.payment_intents.all(since="2025-01-01", until="2025-02-01")
+payment_intents = client.payment_intents.list(since="2025-01-01", until="2025-02-01")
 ```
 
 You can also pass the `lazy=False` parameter to the method to force the SDK to return a list of all the instances of the resource instead of the generator. **Beware**: this could take **very long**, depending on the amount of instances that exist of said resource:
 
 ```python
-payment_intents = client.payment_intents.all(since="2025-01-01", until="2025-02-01", lazy=False)
+payment_intents = client.payment_intents.list(since="2025-01-01", until="2025-02-01", lazy=False)
 
 isinstance(payment_intents, list)  # True
 ```
@@ -236,7 +236,7 @@ client = Fintoc("your_api_key", jws_private_key=os.environ.get('JWS_PRIVATE_KEY'
 Any resource of the SDK can be serialized! To get the serialized resource, just call the `serialize` method!
 
 ```python
-payment_intent = client.payment_intents.all(lazy=False)[0]
+payment_intent = client.payment_intents.list(lazy=False)[0]
 
 serialization = payment_intent.serialize()
 ```

--- a/fintoc/managers/accounts_manager.py
+++ b/fintoc/managers/accounts_manager.py
@@ -10,7 +10,7 @@ class AccountsManager(ManagerMixin):
     """Represents an accounts manager."""
 
     resource = "account"
-    methods = ["all", "get"]
+    methods = ["list", "get"]
 
     def __init__(self, path, client):
         super().__init__(path, client)

--- a/fintoc/managers/charges_manager.py
+++ b/fintoc/managers/charges_manager.py
@@ -8,4 +8,4 @@ class ChargesManager(ManagerMixin):
     """Represents a charges manager."""
 
     resource = "charge"
-    methods = ["all", "get", "create"]
+    methods = ["list", "get", "create"]

--- a/fintoc/managers/invoices_manager.py
+++ b/fintoc/managers/invoices_manager.py
@@ -8,4 +8,4 @@ class InvoicesManager(ManagerMixin):
     """Represents an invoices manager."""
 
     resource = "invoice"
-    methods = ["all"]
+    methods = ["list"]

--- a/fintoc/managers/links_manager.py
+++ b/fintoc/managers/links_manager.py
@@ -8,7 +8,7 @@ class LinksManager(ManagerMixin):
     """Represents a links manager."""
 
     resource = "link"
-    methods = ["all", "get", "update", "delete"]
+    methods = ["list", "get", "update", "delete"]
 
     def post_get_handler(self, object_, identifier, **kwargs):
         # pylint: disable=protected-access

--- a/fintoc/managers/movements_manager.py
+++ b/fintoc/managers/movements_manager.py
@@ -8,4 +8,4 @@ class MovementsManager(ManagerMixin):
     """Represents a movements manager."""
 
     resource = "movement"
-    methods = ["all", "get"]
+    methods = ["list", "get"]

--- a/fintoc/managers/payment_intents_manager.py
+++ b/fintoc/managers/payment_intents_manager.py
@@ -8,4 +8,4 @@ class PaymentIntentsManager(ManagerMixin):
     """Represents a payment_intents manager."""
 
     resource = "payment_intent"
-    methods = ["all", "get", "create"]
+    methods = ["list", "get", "create"]

--- a/fintoc/managers/refresh_intents_manager.py
+++ b/fintoc/managers/refresh_intents_manager.py
@@ -8,4 +8,4 @@ class RefreshIntentsManager(ManagerMixin):
     """Represents a refresh_intents manager."""
 
     resource = "refresh_intent"
-    methods = ["all", "get", "create"]
+    methods = ["list", "get", "create"]

--- a/fintoc/managers/subscription_intents_manager.py
+++ b/fintoc/managers/subscription_intents_manager.py
@@ -8,4 +8,4 @@ class SubscriptionIntentsManager(ManagerMixin):
     """Represents a subscription_intents manager."""
 
     resource = "subscription_intent"
-    methods = ["all", "get", "create"]
+    methods = ["list", "get", "create"]

--- a/fintoc/managers/subscriptions_manager.py
+++ b/fintoc/managers/subscriptions_manager.py
@@ -8,4 +8,4 @@ class SubscriptionsManager(ManagerMixin):
     """Represents a subscriptions manager."""
 
     resource = "subscription"
-    methods = ["all", "get"]
+    methods = ["list", "get"]

--- a/fintoc/managers/tax_returns_manager.py
+++ b/fintoc/managers/tax_returns_manager.py
@@ -8,4 +8,4 @@ class TaxReturnsManager(ManagerMixin):
     """Represents a tax_returns manager."""
 
     resource = "tax_return"
-    methods = ["all", "get"]
+    methods = ["list", "get"]

--- a/fintoc/managers/v2/account_numbers_manager.py
+++ b/fintoc/managers/v2/account_numbers_manager.py
@@ -7,4 +7,4 @@ class AccountNumbersManager(ManagerMixin):
     """Represents an account numbers manager."""
 
     resource = "account_number"
-    methods = ["all", "get", "update", "create", "delete"]
+    methods = ["list", "get", "update", "create", "delete"]

--- a/fintoc/managers/v2/accounts_manager.py
+++ b/fintoc/managers/v2/accounts_manager.py
@@ -7,4 +7,4 @@ class AccountsManager(ManagerMixin):
     """Represents an accounts manager."""
 
     resource = "account"
-    methods = ["all", "get", "create"]
+    methods = ["list", "get", "create"]

--- a/fintoc/managers/v2/transfers_manager.py
+++ b/fintoc/managers/v2/transfers_manager.py
@@ -7,4 +7,4 @@ class TransfersManager(ManagerMixin):
     """Represents a transfers manager."""
 
     resource = "transfer"
-    methods = ["all", "get", "create"]
+    methods = ["list", "get", "create"]

--- a/fintoc/managers/webhook_endpoints_manager.py
+++ b/fintoc/managers/webhook_endpoints_manager.py
@@ -8,4 +8,4 @@ class WebhookEndpointsManager(ManagerMixin):
     """Represents a webhook_endpoints manager."""
 
     resource = "webhook_endpoint"
-    methods = ["all", "get", "create", "update", "delete"]
+    methods = ["list", "get", "create", "update", "delete"]

--- a/fintoc/resource_handlers.py
+++ b/fintoc/resource_handlers.py
@@ -3,8 +3,8 @@
 from fintoc.utils import objetize, objetize_generator
 
 
-def resource_all(client, path, klass, handlers, methods, params):
-    """Fetch all the instances of a resource."""
+def resource_list(client, path, klass, handlers, methods, params):
+    """List all the instances of a resource."""
     lazy = params.pop("lazy", True)
     data = client.request(path, paginated=True, params=params)
     if lazy:

--- a/fintoc/utils.py
+++ b/fintoc/utils.py
@@ -1,6 +1,8 @@
 """Module to hold every generalized utility on the SDK."""
 
 import datetime
+import functools
+import warnings
 from importlib import import_module
 
 import httpx
@@ -112,3 +114,23 @@ def objetize_generator(generator, klass, client, handlers={}, methods=[], path=N
     """
     for element in generator:
         yield objetize(klass, client, element, handlers, methods, path)
+
+
+def deprecate(message=None):
+    """
+    Decorator to mark functions or methods as deprecated.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            warning_message = message or (
+                f"{func.__name__} is deprecated and will be removed in a"
+                " future version."
+            )
+            warnings.warn(warning_message, category=DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/mixins/test_manager_mixin.py
+++ b/tests/mixins/test_manager_mixin.py
@@ -11,7 +11,7 @@ class InvalidMethodsMockManager(ManagerMixin):
 
 
 class InvalidResourceMockManager(ManagerMixin):
-    methods = ["all", "get", "create", "update", "delete"]
+    methods = ["list", "get", "create", "update", "delete"]
 
 
 class IncompleteMockManager(ManagerMixin):
@@ -21,15 +21,15 @@ class IncompleteMockManager(ManagerMixin):
 
 class EmptyMockManager(ManagerMixin):
     resource = "this_resource_does_not_exist"
-    methods = ["all", "get", "create", "update", "delete"]
+    methods = ["list", "get", "create", "update", "delete"]
 
 
 class ComplexMockManager(ManagerMixin):
     resource = "this_resource_does_not_exist"
-    methods = ["all", "get", "create", "update", "delete"]
+    methods = ["list", "get", "create", "update", "delete"]
 
-    def post_all_handler(self, objects, **kwargs):
-        print("Executing the 'post all' handler")
+    def post_list_handler(self, objects, **kwargs):
+        print("Executing the 'post list' handler")
         return objects
 
     def post_get_handler(self, object_, identifier, **kwargs):
@@ -110,13 +110,24 @@ class TestManagerMixinMethods:
         self.path = "/resources"
         self.manager = EmptyMockManager(self.path, self.client)
 
-    def test_all_lazy_method(self):
+    def test_list_lazy_method(self):
+        objects = self.manager.list()
+        assert isinstance(objects, GeneratorType)
+        for object_ in objects:
+            assert isinstance(object_, ResourceMixin)
+
+    def test_list_not_lazy_method(self):
+        objects = self.manager.list(lazy=False)
+        assert isinstance(objects, list)
+        for object_ in objects:
+            assert isinstance(object_, ResourceMixin)
+
+    def test_all_still_works_for_backwards_compatibility(self):
         objects = self.manager.all()
         assert isinstance(objects, GeneratorType)
         for object_ in objects:
             assert isinstance(object_, ResourceMixin)
 
-    def test_all_not_lazy_method(self):
         objects = self.manager.all(lazy=False)
         assert isinstance(objects, list)
         for object_ in objects:
@@ -169,10 +180,10 @@ class TestManagerMixinHandlers:
         self.path = "/resources"
         self.manager = ComplexMockManager(self.path, self.client)
 
-    def test_all_handler(self, capsys):
-        self.manager.all()
+    def test_list_handler(self, capsys):
+        self.manager.list()
         captured = capsys.readouterr().out
-        assert "all" in captured
+        assert "list" in captured
 
     def test_get_handler(self, capsys):
         self.manager.get("my_id")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,9 +18,9 @@ class TestFintocIntegration:
         self.api_key = "test_api_key"
         self.fintoc = Fintoc(self.api_key)
 
-    def test_links_all(self):
-        """Test that fintoc.links.all() calls the correct URL."""
-        links = list(self.fintoc.links.all())
+    def test_links_list(self):
+        """Test that fintoc.links.list() calls the correct URL."""
+        links = list(self.fintoc.links.list())
 
         assert len(links) > 0
         for link in links:
@@ -55,7 +55,7 @@ class TestFintocIntegration:
 
         assert result == link_id
 
-    def test_link_accounts_all(self):
+    def test_link_accounts_list(self):
         """Test getting accounts from a link."""
 
         def assert_accounts(accounts):
@@ -69,10 +69,10 @@ class TestFintocIntegration:
 
         # Test using the resource
         link = self.fintoc.links.get(link_token)
-        assert_accounts(list(link.accounts.all()))
+        assert_accounts(list(link.accounts.list()))
 
         # Test using directly the manager
-        assert_accounts(list(self.fintoc.accounts.all(link_token=link_token)))
+        assert_accounts(list(self.fintoc.accounts.list(link_token=link_token)))
 
     def test_link_account_get(self):
         """Test getting a specific account from a link."""
@@ -94,7 +94,7 @@ class TestFintocIntegration:
         account = self.fintoc.accounts.get(account_id, link_token=link_token)
         assert_account(account)
 
-    def test_account_movements_all(self):
+    def test_account_movements_list(self):
         """Test getting movements from an account."""
 
         def assert_movements(movements):
@@ -110,12 +110,12 @@ class TestFintocIntegration:
         # Test using the resource
         link = self.fintoc.links.get(link_token)
         account = link.accounts.get(account_id)
-        assert_movements(list(account.movements.all()))
+        assert_movements(list(account.movements.list()))
 
         # Test using directly the manager
         assert_movements(
             list(
-                self.fintoc.accounts.movements.all(
+                self.fintoc.accounts.movements.list(
                     account_id=account_id, link_token=link_token
                 )
             )
@@ -145,7 +145,7 @@ class TestFintocIntegration:
         )
         assert_movement(movement)
 
-    def test_link_subscriptions_all(self):
+    def test_link_subscriptions_list(self):
         """Test getting all subscriptions from a link."""
 
         def assert_subscriptions(subscriptions):
@@ -159,10 +159,10 @@ class TestFintocIntegration:
         # Test using the resource. This actually should be removed, because
         # subscriptions do not depend on a link.
         link = self.fintoc.links.get(link_token)
-        assert_subscriptions(list(link.subscriptions.all()))
+        assert_subscriptions(list(link.subscriptions.list()))
 
         # Test using directly the manager
-        assert_subscriptions(list(self.fintoc.subscriptions.all()))
+        assert_subscriptions(list(self.fintoc.subscriptions.list()))
 
     def test_link_subscription_get(self):
         """Test getting a specific subscription from a link."""
@@ -185,7 +185,7 @@ class TestFintocIntegration:
         )
         assert_subscription(subscription)
 
-    def test_link_tax_returns_all(self):
+    def test_link_tax_returns_list(self):
         """Test getting all tax returns from a link."""
 
         def assert_tax_returns(tax_returns):
@@ -199,10 +199,10 @@ class TestFintocIntegration:
 
         # Test using the resource
         link = self.fintoc.links.get(link_token)
-        assert_tax_returns(list(link.tax_returns.all()))
+        assert_tax_returns(list(link.tax_returns.list()))
 
         # Test using directly the manager
-        assert_tax_returns(list(self.fintoc.tax_returns.all(link_token=link_token)))
+        assert_tax_returns(list(self.fintoc.tax_returns.list(link_token=link_token)))
 
     def test_link_tax_return_get(self):
         """Test getting a specific tax return from a link."""
@@ -224,7 +224,7 @@ class TestFintocIntegration:
         tax_return = self.fintoc.tax_returns.get(tax_return_id, link_token=link_token)
         assert_tax_return(tax_return)
 
-    def test_link_invoices_all(self):
+    def test_link_invoices_list(self):
         """Test getting all invoices from a link."""
 
         def assert_invoices(invoices):
@@ -238,12 +238,12 @@ class TestFintocIntegration:
 
         # Test using the resource
         link = self.fintoc.links.get(link_token)
-        assert_invoices(list(link.invoices.all()))
+        assert_invoices(list(link.invoices.list()))
 
         # Test using directly the manager
-        assert_invoices(list(self.fintoc.invoices.all(link_token=link_token)))
+        assert_invoices(list(self.fintoc.invoices.list(link_token=link_token)))
 
-    def test_link_refresh_intents_all(self):
+    def test_link_refresh_intents_list(self):
         """Test getting all refresh intents from a link."""
 
         def assert_refresh_intents(refresh_intents):
@@ -257,11 +257,11 @@ class TestFintocIntegration:
 
         # Test using the resource
         link = self.fintoc.links.get(link_token)
-        assert_refresh_intents(list(link.refresh_intents.all()))
+        assert_refresh_intents(list(link.refresh_intents.list()))
 
         # Test using directly the manager
         assert_refresh_intents(
-            list(self.fintoc.refresh_intents.all(link_token=link_token))
+            list(self.fintoc.refresh_intents.list(link_token=link_token))
         )
 
     def test_link_refresh_intent_get(self):
@@ -315,9 +315,9 @@ class TestFintocIntegration:
         )
         assert_refresh_intent(refresh_intent)
 
-    def test_charges_all(self):
+    def test_charges_list(self):
         """Test getting all charges."""
-        charges = list(self.fintoc.charges.all())
+        charges = list(self.fintoc.charges.list())
 
         assert len(charges) > 0
         for charge in charges:
@@ -349,9 +349,9 @@ class TestFintocIntegration:
         assert charge.json.currency == charge_data["currency"]
         assert charge.json.payment_method == charge_data["payment_method"]
 
-    def test_payment_intents_all(self):
+    def test_payment_intents_list(self):
         """Test getting all payment intents."""
-        payment_intents = list(self.fintoc.payment_intents.all())
+        payment_intents = list(self.fintoc.payment_intents.list())
 
         assert len(payment_intents) > 0
         for payment_intent in payment_intents:
@@ -385,9 +385,9 @@ class TestFintocIntegration:
             payment_intent.json.payment_method == payment_intent_data["payment_method"]
         )
 
-    def test_subscription_intents_all(self):
+    def test_subscription_intents_list(self):
         """Test getting all subscription intents."""
-        subscription_intents = list(self.fintoc.subscription_intents.all())
+        subscription_intents = list(self.fintoc.subscription_intents.list())
 
         assert len(subscription_intents) > 0
         for subscription_intent in subscription_intents:
@@ -421,9 +421,9 @@ class TestFintocIntegration:
         assert subscription_intent.json.amount == subscription_intent_data["amount"]
         assert subscription_intent.json.currency == subscription_intent_data["currency"]
 
-    def test_webhook_endpoints_all(self):
+    def test_webhook_endpoints_list(self):
         """Test getting all webhook endpoints."""
-        webhook_endpoints = list(self.fintoc.webhook_endpoints.all())
+        webhook_endpoints = list(self.fintoc.webhook_endpoints.list())
 
         assert len(webhook_endpoints) > 0
         for webhook_endpoint in webhook_endpoints:
@@ -483,9 +483,9 @@ class TestFintocIntegration:
 
         assert result == webhook_endpoint_id
 
-    def test_v2_accounts_all(self):
+    def test_v2_accounts_list(self):
         """Test getting all accounts using v2 API."""
-        accounts = list(self.fintoc.v2.accounts.all())
+        accounts = list(self.fintoc.v2.accounts.list())
 
         assert len(accounts) > 0
         for account in accounts:
@@ -511,11 +511,11 @@ class TestFintocIntegration:
         assert account.url == "v2/accounts"
         assert account.json.description == account_data["description"]
 
-    def test_v2_account_numbers_all(self):
+    def test_v2_account_numbers_list(self):
         """Test getting all account numbers using v2 API."""
         account_id = "test_account_id"
         account_numbers = list(
-            self.fintoc.v2.account_numbers.all(account_id=account_id)
+            self.fintoc.v2.account_numbers.list(account_id=account_id)
         )
 
         assert len(account_numbers) > 0
@@ -571,10 +571,10 @@ class TestFintocIntegration:
 
         assert result == account_number_id
 
-    def test_v2_transfers_all(self):
+    def test_v2_transfers_list(self):
         """Test getting all transfers using v2 API."""
         account_id = "test_account_id"
-        transfers = list(self.fintoc.v2.transfers.all(account_id=account_id))
+        transfers = list(self.fintoc.v2.transfers.list(account_id=account_id))
 
         assert len(transfers) > 0
         for transfer in transfers:


### PR DESCRIPTION
## Description

Listing resources is now done using `list()` instead of `all()`. This change aligns the SDK better with our API documentation, where we consistently use `list()`.

For backward compatibility, customers can still use `all()`, but they'll receive a warning prompting them to migrate to `list()`.

```python
from fintoc import Fintoc

client = Fintoc("your_api_key")

# list all succeeded payment intents since the beginning of 2025
payment_intents = client.payment_intents.list(since="2025-01-01", status="succeeded")
```

## Requirements

None.

## Additional changes

None.
