### PR TITLE
Pass the raw body to the signature generator instead of an object

### DIFF
--- a/fintoc/client.py
+++ b/fintoc/client.py
@@ -2,8 +2,8 @@
 Module to house the Client object of the Fintoc Python SDK.
 """
 
-import uuid
 import urllib
+import uuid
 from json.decoder import JSONDecodeError
 
 import httpx
@@ -87,7 +87,8 @@ class Client:
         Uses the internal httpx client to make a simple or paginated request.
         """
         url = (
-            path if urllib.parse.urlparse(path).scheme
+            path
+            if urllib.parse.urlparse(path).scheme
             else f"{self.base_url}/{path.lstrip('/')}"
         )
 

--- a/fintoc/paginator.py
+++ b/fintoc/paginator.py
@@ -6,28 +6,28 @@ from functools import reduce
 from fintoc.constants import LINK_HEADER_PATTERN
 
 
-def paginate(client, path, headers, params):
+def paginate(client, url, params):
     """
     Fetch a paginated resource and return a generator with all of
     its instances.
     """
-    response = request(client, path, headers=headers, params=params)
+    response = request(client, url, params=params)
     elements = response["elements"]
     for element in elements:
         yield element
     while response.get("next"):
-        response = request(client, response.get("next"), headers=headers)
+        response = request(client, response.get("next"))
         elements = response["elements"]
         for element in elements:
             yield element
 
 
-def request(client, path, headers={}, params={}):
+def request(client, url, params={}):
     """
     Fetch a page of a resource and return its elements and the next
     page of the resource.
     """
-    response = client.request("get", path, headers=headers, params=params)
+    response = client.request("get", url, params=params)
     response.raise_for_status()
     headers = parse_link_headers(response.headers.get("link"))
     next_ = headers and headers.get("next")

--- a/fintoc/paginator.py
+++ b/fintoc/paginator.py
@@ -3,31 +3,44 @@
 import re
 from functools import reduce
 
+import httpx
+
 from fintoc.constants import LINK_HEADER_PATTERN
 
 
-def paginate(client, url, params):
+def paginate(
+    client: httpx.Client,
+    url: str,
+    params: dict[str, str] = {},
+    headers: dict[str, str] = {},
+):
     """
     Fetch a paginated resource and return a generator with all of
     its instances.
     """
-    response = request(client, url, params=params)
+    response = request(client, url, params=params, headers=headers)
     elements = response["elements"]
     for element in elements:
         yield element
     while response.get("next"):
-        response = request(client, response.get("next"))
+        response = request(client, response.get("next"), headers=headers)
         elements = response["elements"]
         for element in elements:
             yield element
 
 
-def request(client, url, params={}):
+def request(
+    client: httpx.Client,
+    url: str,
+    params: dict[str, str] = {},
+    headers: dict[str, str] = {},
+):
     """
     Fetch a page of a resource and return its elements and the next
     page of the resource.
     """
-    response = client.request("get", url, params=params)
+    _request = httpx.Request("get", url, params=params, headers=headers)
+    response = client.send(_request)
     response.raise_for_status()
     headers = parse_link_headers(response.headers.get("link"))
     next_ = headers and headers.get("next")
@@ -38,7 +51,7 @@ def request(client, url, params={}):
     }
 
 
-def parse_link_headers(link_header):
+def parse_link_headers(link_header: str):
     """
     Receive the 'link' header and return a dictionary with
     every key: value instance present on the header.
@@ -48,7 +61,7 @@ def parse_link_headers(link_header):
     return reduce(parse_link, link_header.split(","), {})
 
 
-def parse_link(dictionary, link):
+def parse_link(dictionary: dict[str, str], link: str):
     """
     Receive a dictionary with already parsed key: values from the
     'link' header along with another link and return the original

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def patch_http_client(monkeypatch):
             inner_params = {y[0]: y[1] for y in (x.split("=") for x in query)}
             complete_params = {
                 **inner_params,
-                **({} if request.url.params is None else request.url.params)
+                **({} if request.url.params is None else request.url.params),
             }
             usable_url = request.url.path
             raw_body = request.content.decode("utf-8")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ Module to hold all the fixtures and stuff that needs to get auto-imported
 by PyTest.
 """
 
+import json
 from json.decoder import JSONDecodeError
 
 import httpx
@@ -96,13 +97,23 @@ def patch_http_client(monkeypatch):
             }
 
     class MockClient(httpx.Client):
-        def request(self, method, url, params=None, json=None, headers=None, **kwargs):
-            query = url.split("?")[-1].split("&") if "?" in url else []
+        def send(self, request: httpx.Request, **_kwargs):
+            query_string = request.url.query.decode("utf-8")
+            query = query_string.split("&") if query_string else []
             inner_params = {y[0]: y[1] for y in (x.split("=") for x in query)}
-            complete_params = {**inner_params, **({} if params is None else params)}
-            usable_url = url.split("//")[-1].split("/", 1)[-1].split("?")[0]
+            complete_params = {
+                **inner_params,
+                **({} if request.url.params is None else request.url.params)
+            }
+            usable_url = request.url.path
+            raw_body = request.content.decode("utf-8")
             return MockResponse(
-                method, self.base_url, usable_url, complete_params, json, headers
+                request.method.lower(),
+                self.base_url,
+                usable_url.lstrip("/"),
+                complete_params,
+                json.loads(raw_body) if raw_body else None,
+                request.headers,
             )
 
     monkeypatch.setattr(httpx, "Client", MockClient)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -121,7 +121,7 @@ class TestClientRequestFunctionality:
         data = self.client.request("/v2/transfers", method="post")
         assert isinstance(data, dict)
 
-        idempotency_key = data["headers"]["Idempotency-Key"]
+        idempotency_key = data["headers"]["idempotency-key"]
         assert idempotency_key is not None and idempotency_key != ""
 
     def test_post_request_with_custom_idempotency_key(self):
@@ -130,5 +130,5 @@ class TestClientRequestFunctionality:
         )
         assert isinstance(data, dict)
 
-        idempotency_key = data["headers"]["Idempotency-Key"]
+        idempotency_key = data["headers"]["idempotency-key"]
         assert idempotency_key == "1234"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -63,6 +63,7 @@ class TestFintocIntegration:
             for account in accounts:
                 assert account.method == "get"
                 assert account.url == "v1/accounts"
+                assert account.params.link_token == link_token
 
         link_token = "test_link_token"
 
@@ -101,6 +102,7 @@ class TestFintocIntegration:
             for movement in movements:
                 assert movement.method == "get"
                 assert movement.url == f"v1/accounts/{account_id}/movements"
+                assert movement.params.link_token == link_token
 
         link_token = "test_link_token"
         account_id = "test_account_id"
@@ -191,6 +193,7 @@ class TestFintocIntegration:
             for tax_return in tax_returns:
                 assert tax_return.method == "get"
                 assert tax_return.url == "v1/tax_returns"
+                assert tax_return.params.link_token == link_token
 
         link_token = "test_link_token"
 
@@ -229,6 +232,7 @@ class TestFintocIntegration:
             for invoice in invoices:
                 assert invoice.method == "get"
                 assert invoice.url == "v1/invoices"
+                assert invoice.params.link_token == link_token
 
         link_token = "test_link_token"
 
@@ -247,6 +251,7 @@ class TestFintocIntegration:
             for refresh_intent in refresh_intents:
                 assert refresh_intent.method == "get"
                 assert refresh_intent.url == "v1/refresh_intents"
+                assert refresh_intent.params.link_token == link_token
 
         link_token = "test_link_token"
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -63,7 +63,6 @@ class TestFintocIntegration:
             for account in accounts:
                 assert account.method == "get"
                 assert account.url == "v1/accounts"
-                assert account.params.link_token == link_token
 
         link_token = "test_link_token"
 
@@ -102,7 +101,6 @@ class TestFintocIntegration:
             for movement in movements:
                 assert movement.method == "get"
                 assert movement.url == f"v1/accounts/{account_id}/movements"
-                assert movement.params.link_token == link_token
 
         link_token = "test_link_token"
         account_id = "test_account_id"
@@ -193,7 +191,6 @@ class TestFintocIntegration:
             for tax_return in tax_returns:
                 assert tax_return.method == "get"
                 assert tax_return.url == "v1/tax_returns"
-                assert tax_return.params.link_token == link_token
 
         link_token = "test_link_token"
 
@@ -232,7 +229,6 @@ class TestFintocIntegration:
             for invoice in invoices:
                 assert invoice.method == "get"
                 assert invoice.url == "v1/invoices"
-                assert invoice.params.link_token == link_token
 
         link_token = "test_link_token"
 
@@ -251,7 +247,6 @@ class TestFintocIntegration:
             for refresh_intent in refresh_intents:
                 assert refresh_intent.method == "get"
                 assert refresh_intent.url == "v1/refresh_intents"
-                assert refresh_intent.params.link_token == link_token
 
         link_token = "test_link_token"
 
@@ -614,7 +609,7 @@ class TestFintocIntegration:
         assert transfer.json.description == description
         assert transfer.json.metadata.test_key == metadata["test_key"]
 
-        idempotency_key_header = transfer.serialize()["headers"]["Idempotency-Key"]
+        idempotency_key_header = getattr(transfer.headers, "idempotency-key")
         assert idempotency_key_header is not None and idempotency_key_header != ""
 
         idempotency_key = "123456"
@@ -626,7 +621,7 @@ class TestFintocIntegration:
             metadata=metadata,
             idempotency_key=idempotency_key,
         )
-        idempotency_key_header = transfer.serialize()["headers"]["Idempotency-Key"]
+        idempotency_key_header = getattr(transfer.headers, "idempotency-key")
         assert idempotency_key_header == "123456"
 
     def test_v2_simulate_receive_transfer(self):

--- a/tests/test_paginator.py
+++ b/tests/test_paginator.py
@@ -78,9 +78,7 @@ class TestRequest:
 
     def test_request_params_get_passed_to_next_url(self):
         client = httpx.Client(base_url="https://test.com")
-        data = request(
-            client, "/movements", params={"link_token": "sample_link_token"}
-        )
+        data = request(client, "/movements", params={"link_token": "sample_link_token"})
         assert "next" in data
         assert "link_token=sample_link_token" in data["next"]
 

--- a/tests/test_paginator.py
+++ b/tests/test_paginator.py
@@ -79,7 +79,7 @@ class TestRequest:
     def test_request_params_get_passed_to_next_url(self):
         client = httpx.Client(base_url="https://test.com")
         data = request(
-            client, "/movements", headers={}, params={"link_token": "sample_link_token"}
+            client, "/movements", params={"link_token": "sample_link_token"}
         )
         assert "next" in data
         assert "link_token=sample_link_token" in data["next"]
@@ -92,7 +92,7 @@ class TestPaginate:
 
     def test_pagination(self):
         client = httpx.Client(base_url="https://test.com")
-        data = paginate(client, "/movements", {}, {})
+        data = paginate(client, "/movements", {})
         assert isinstance(data, GeneratorType)
 
         elements = list(data)

--- a/tests/test_paginator.py
+++ b/tests/test_paginator.py
@@ -90,7 +90,7 @@ class TestPaginate:
 
     def test_pagination(self):
         client = httpx.Client(base_url="https://test.com")
-        data = paginate(client, "/movements", {})
+        data = paginate(client, "/movements", {}, {})
         assert isinstance(data, GeneratorType)
 
         elements = list(data)


### PR DESCRIPTION
## Description

The SDK was having bugs when generating the signature. This is because the signature generation process received a JSON and had to serialize it, instead of receiving the raw text sent with the request (the one used by the server to check the signature), so the chances of different serialization algorithms were high.

## Requirements

N/A

## Additional changes

N/A
