### PR TITLE
Removed delete method for account number manager

### DIFF
--- a/fintoc/managers/v2/account_numbers_manager.py
+++ b/fintoc/managers/v2/account_numbers_manager.py
@@ -7,4 +7,4 @@ class AccountNumbersManager(ManagerMixin):
     """Represents an account numbers manager."""
 
     resource = "account_number"
-    methods = ["list", "get", "update", "create", "delete"]
+    methods = ["list", "get", "update", "create"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -563,14 +563,6 @@ class TestFintocIntegration:
         assert account_number.url == f"v2/account_numbers/{account_number_id}"
         assert account_number.json.metadata.test_key == metadata["test_key"]
 
-    def test_v2_account_number_delete(self):
-        """Test deleting an account number using v2 API."""
-        account_number_id = "test_account_number_id"
-
-        result = self.fintoc.v2.account_numbers.delete(account_number_id)
-
-        assert result == account_number_id
-
     def test_v2_transfers_list(self):
         """Test getting all transfers using v2 API."""
         account_id = "test_account_id"


### PR DESCRIPTION
## Description

Since account numbers can't be deleted (all changes regarding a account number must be made through the patch endpoint), this PR removes the delete method from the account numbers manager.

## Requirements

None.

## Additional changes
- Deleted the test for the delete account number method.
