### PR TITLE
[TRNF-3299] add return action to sdk

### DIFF
--- a/fintoc/managers/v2/transfers_manager.py
+++ b/fintoc/managers/v2/transfers_manager.py
@@ -7,4 +7,9 @@ class TransfersManager(ManagerMixin):
     """Represents a transfers manager."""
 
     resource = "transfer"
-    methods = ["list", "get", "create"]
+    methods = ["list", "get", "create", "return_"]
+
+    def _return_(self, **kwargs):
+        """Return a transfer."""
+        path = f"{self._build_path(**kwargs)}/return"
+        return self._create(path_=path, **kwargs)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -726,6 +726,16 @@ class TestFintocIntegration:
         assert result.method == "post"
         assert result.url == f"v1/checkout_sessions/{checkout_session_id}/expire"
 
+    def test_v2_transfer_return(self):
+        """Test returning a transfer using v2 API."""
+        transfer_id = "test_transfer_id"
+
+        result = self.fintoc.v2.transfers.return_(transfer_id=transfer_id)
+
+        assert result.method == "post"
+        assert result.url == "v2/transfers/return"
+        assert result.json.transfer_id == transfer_id
+
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
## Summary

This PR adds support for the return transfer endpoint to the Fintoc Python SDK.

## Usage Example

```python
from fintoc import Fintoc

fintoc = Fintoc("your-api-key")

# Create a checkout session
transfer = fintoc.transfers.return(
    transfer_id='tr_...',
)
```