### PR TITLE
[EXP-3224] Add expire functionality to payment intents

### DIFF
--- a/fintoc/managers/payment_intents_manager.py
+++ b/fintoc/managers/payment_intents_manager.py
@@ -8,4 +8,9 @@ class PaymentIntentsManager(ManagerMixin):
     """Represents a payment_intents manager."""
 
     resource = "payment_intent"
-    methods = ["list", "get", "create"]
+    methods = ["list", "get", "create", "expire"]
+
+    def _expire(self, identifier, **kwargs):
+        """Expire a payment intent."""
+        path = f"{self._build_path(**kwargs)}/{identifier}/expire"
+        return self._create(path_=path, **kwargs)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -383,6 +383,15 @@ class TestFintocIntegration:
         assert payment_intent.json.currency == payment_intent_data["currency"]
         assert payment_intent.json.payment_type == payment_intent_data["payment_type"]
 
+    def test_payment_intent_expire(self):
+        """Test expiring a payment intent."""
+        payment_intent_id = "test_payment_intent_id"
+
+        result = self.fintoc.payment_intents.expire(payment_intent_id)
+
+        assert result.method == "post"
+        assert result.url == f"v1/payment_intents/{payment_intent_id}/expire"
+
     def test_subscription_intents_list(self):
         """Test getting all subscription intents."""
         subscription_intents = list(self.fintoc.subscription_intents.list())


### PR DESCRIPTION
## Description

Adds expire functionality to payment intents, following the same pattern as checkout sessions.
We need it for cash.

### Changes:
- Added `expire` method to `PaymentIntentsManager`
- Added integration test for expire functionality
- Updated README with expire example

### Usage:
```python
client.payment_intents.expire(payment_intent_id)
```

## Requirements

None.

## Additional changes

None.