### PR TITLE
[DX-586] migrate release to fin-releases composite action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,25 @@
 name: release
 
 on:
-  push:
-    branches:
-      - stable
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Tipo de bump'
+        type: choice
+        required: true
+        default: minor
+        options: [patch, minor, major]
+      release-notes:
+        description: 'Release notes (markdown, opcional)'
+        type: string
+        required: false
 
 jobs:
-  pypi-release:
+  release:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout to commit code
         uses: actions/checkout@v3
@@ -32,6 +44,15 @@ jobs:
       - name: Install dependencies
         if: steps.poetry-cache.outputs.cache-hit != 'true'
         run: poetry install
+
+      - uses: fintoc-com/release-action/prepare@main
+        id: prep
+        with:
+          bump: ${{ inputs.bump }}
+          version-format: py
+          tag-prefix: v
+          app-id: ${{ vars.FIN_RELEASES_APP_ID }}
+          app-private-key: ${{ secrets.FIN_RELEASES_PRIVATE_KEY }}
 
       - name: Build the package
         run: poetry build
@@ -42,53 +63,9 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
-  github-release:
-    needs: pypi-release
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout to commit code
-        uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: fintoc-com/release-action/finalize@main
         with:
-          python-version: "3.10.6"
-
-      - name: Install Poetry
-        run: |
-          make get-poetry
-          echo $HOME/.poetry/bin >> $GITHUB_PATH
-
-      - name: Set up environment cache
-        uses: actions/cache@v3
-        id: environment-cache
-        with:
-          key: environment-cache-v1-${{ hashFiles('**/poetry.lock') }}
-          path: .venv
-
-      - name: Install dependencies
-        if: steps.poetry-cache.outputs.cache-hit != 'true'
-        run: poetry install
-
-      - name: Get version
-        id: version
-        run: echo ::set-output name=version::$(poetry version | rev | cut -d' ' -f1 | rev)
-
-      - name: Get Pull Request data
-        uses: jwalton/gh-find-current-pr@v1
-        id: find-pr
-        with:
-          state: all
-
-      - name: Tag and Release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          release_name: ${{ steps.version.outputs.version }}
-          body: |
-            ${{ steps.find-pr.outputs.body }}
-          draft: false
-          prerelease: false
+          tag: ${{ steps.prep.outputs.tag }}
+          release-notes: ${{ inputs.release-notes }}
+          app-id: ${{ vars.FIN_RELEASES_APP_ID }}
+          app-private-key: ${{ secrets.FIN_RELEASES_PRIVATE_KEY }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,26 @@
-Releasing
-=========
+# Releasing
 
-1. From `master`, bump the package version, using `make bump! minor` (you can bump `patch`, `minor` or `major`).
-2. Push the new branch to `origin`.
-3. After merging the bumped version to `master`, make a Pull Request from `master` to `stable`. Make sure to include every change, using the template located at `.github/PULL_REQUEST_TEMPLATE/release.md`.
-4. Merge the Pull Request.
+Manual desde Actions. Toma ~2–3 min.
+
+## Cómo
+
+1. https://github.com/fintoc-com/fintoc-python/actions → **release** → **Run workflow**.
+2. `bump`: `patch` / `minor` / `major`. `release-notes`: markdown opcional.
+3. **Run workflow**. Solo corre desde `master`.
+
+## Qué hace
+
+`make get-poetry` + `poetry install` →
+[`release/prepare`](https://github.com/fintoc-com/release-action/tree/main/prepare) bumpea local →
+`poetry build` →
+`pypa/gh-action-pypi-publish` (con `PYPI_API_TOKEN`) →
+[`release/finalize`](https://github.com/fintoc-com/release-action/tree/main/finalize) pushea commit + tag, crea GitHub Release.
+
+Todo autoreado por `fin-releases[bot]`.
+
+## Si falla
+
+| Falla en | Estado | Recovery |
+|---|---|---|
+| Antes o durante `pypi-publish` | Nada en el remote | Re-run |
+| `release/finalize` (post-publish) | Paquete en PyPI, sin tag/release | PR con el commit del bump + `gh release create vX.Y.Z` |


### PR DESCRIPTION
## Description

Migra el flow de release de fintoc-python al patrón compartido con los otros SDKs (`release/prepare` → `pypi-publish` → `release/finalize`) usando las composite actions de [`fintoc-com/release-action`](https://github.com/fintoc-com/release-action).


### Diferencias vs hoy

| | Hoy | Este PR |
|---|---|---|
| Trigger | push a `stable` (via PR `master → stable`) | botón en Actions |
| Bump | manual en PR `release/prepare-X.Y.Z` | dropdown en el dispatch |
| Identidad commit/tag/release | `github-actions[bot]` | `fin-releases[bot]` (App) |
| Tag + GH Release | `actions/create-release@latest` (deprecated) | `gh release create` via finalize |
| Changelog | body extraído del último PR con `jwalton/gh-find-current-pr` | input `release-notes` en el dispatch |
| `set-output ::` | sí | reemplazado |
| `stable` branch | trigger del release | sin trigger; queda como histórico |
| Convención de tags | `2.20.0` (sin prefix) | `v2.20.1` con prefix (alineado con resto del ecosistema) |

### Failure recovery

| Falla en | Estado | Recovery |
|---|---|---|
| Cualquier step antes de `pypi-publish` | Nada en el remote | Re-run |
| `pypi-publish` | Bump + tag solo en el runner (se descartan) | Re-run |
| `release/finalize` (post-publish) | Paquete en PyPI, sin tag/release en GitHub | Manual: PR con el commit del bump + `gh release create` |

## Requirements

- App `fin-releases` instalada en este repo ✓
- Org variable `FIN_RELEASES_APP_ID` y org secret `FIN_RELEASES_PRIVATE_KEY` accesibles desde `fintoc-python` ✓
- App `fin-releases` en bypass de `master` ✓
- `PYPI_API_TOKEN` secret sigue usándose para publish a PyPI (no cambia)

## Additional changes

None.