### PR TITLE
feat: add test webhook events endpoint

### DIFF
--- a/fintoc/managers/webhook_endpoints_manager.py
+++ b/fintoc/managers/webhook_endpoints_manager.py
@@ -8,4 +8,9 @@ class WebhookEndpointsManager(ManagerMixin):
     """Represents a webhook_endpoints manager."""
 
     resource = "webhook_endpoint"
-    methods = ["list", "get", "create", "update", "delete"]
+    methods = ["list", "get", "create", "update", "delete", "test"]
+
+    def _test(self, identifier, **kwargs):
+        """Send a test event to a webhook endpoint."""
+        path = f"{self._build_path(**kwargs)}/{identifier}/test"
+        return self._create(path_=path, **kwargs)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -588,6 +588,17 @@ class TestFintocIntegration:
 
         assert result == webhook_endpoint_id
 
+    def test_webhook_endpoint_test(self):
+        """Test sending a test event to a webhook endpoint."""
+        webhook_endpoint_id = "test_webhook_endpoint_id"
+        test_data = {"type": "link.credentials_changed"}
+
+        result = self.fintoc.webhook_endpoints.test(webhook_endpoint_id, **test_data)
+
+        assert result.method == "post"
+        assert result.url == f"v1/webhook_endpoints/{webhook_endpoint_id}/test"
+        assert result.json.type == test_data["type"]
+
     def test_v2_accounts_list(self):
         """Test getting all accounts using v2 API."""
         accounts = list(self.fintoc.v2.accounts.list())


### PR DESCRIPTION
## Description

Adds support for upcoming endpoint to send test webhook events.

## Requirements

Public API needs to be deployed to prod for this to work, still in review.


None.

## Additional changes

None.
